### PR TITLE
Handle expired/revoked OAuth tokens with Reconnect flow

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -31,6 +31,7 @@ import {
   cloudSyncSettingsStorage,
   cloudCredentialsStorage,
   encryptionKeyStorage,
+  syncStateStorage,
   clearAllCloudSyncData,
   launchGoogleOAuth,
   setupEncryption,
@@ -149,6 +150,7 @@ export type MessageType =
   // Cloud sync messages
   | { type: 'CLOUD_CONNECT' }
   | { type: 'CLOUD_DISCONNECT'; deleteCloudData?: boolean }
+  | { type: 'CLOUD_RECONNECT' }
   | { type: 'CLOUD_SETUP_ENCRYPTION'; password: string; tokens?: CloudTokens; email?: string }
   | { type: 'CLOUD_UNLOCK'; password: string; tokens?: CloudTokens; email?: string }
   | { type: 'CLOUD_REGENERATE_RECOVERY_KEY'; password: string }
@@ -509,7 +511,10 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 
     case ALARM_NAMES.CLOUD_SYNC:
       if ((await syncEngine.isConfigured()) && syncEngine.isUnlocked()) {
-        await syncEngine.performFullSync()
+        const syncState = await syncStateStorage.get()
+        if (!syncState.authExpired) {
+          await syncEngine.performFullSync()
+        }
       }
       break
 
@@ -1184,6 +1189,43 @@ async function handleMessage(message: MessageType): Promise<MessageResponse> {
         await chrome.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
 
         return { success: true }
+      }
+
+      case 'CLOUD_RECONNECT': {
+        if (!(await syncEngine.isConfigured())) {
+          return { success: false, error: 'Cloud sync not configured' }
+        }
+        if (!syncEngine.isUnlocked()) {
+          return { success: false, error: 'Cloud sync is locked' }
+        }
+
+        // Launch fresh OAuth flow
+        const reconnectResult = await launchGoogleOAuth()
+
+        // Encrypt new tokens with existing encryption key
+        const reconnectKey = syncEngine.getEncryptionKeyForSetup()
+        if (!reconnectKey) {
+          return { success: false, error: 'Encryption key not available' }
+        }
+
+        const reconnectEncrypted = await encryptObject(reconnectResult.tokens, reconnectKey)
+
+        // Save new credentials, preserving existing connectedAt
+        const existingCreds = await cloudCredentialsStorage.get()
+        await cloudCredentialsStorage.save({
+          provider: 'gdrive',
+          encryptedTokens: JSON.stringify(reconnectEncrypted),
+          email: reconnectResult.email,
+          connectedAt: existingCreds?.connectedAt ?? Date.now(),
+        })
+
+        // Clear cached tokens so sync engine picks up new ones
+        syncEngine.clearCachedTokens()
+
+        // Clear auth error state
+        await syncStateStorage.update({ authExpired: false, lastError: undefined })
+
+        return { success: true, data: { email: reconnectResult.email } }
       }
 
       case 'CLOUD_SYNC': {

--- a/src/options/components/CloudSyncPanel.tsx
+++ b/src/options/components/CloudSyncPanel.tsx
@@ -17,6 +17,7 @@ interface CloudSyncStatus extends SyncState {
   configured: boolean
   enabled: boolean
   unlocked: boolean
+  authExpired?: boolean
   email?: string
 }
 
@@ -39,6 +40,7 @@ export function CloudSyncPanel({
   const [connecting, setConnecting] = useState(false)
   const [syncing, setSyncing] = useState(false)
   const [disconnecting, setDisconnecting] = useState(false)
+  const [reconnecting, setReconnecting] = useState(false)
 
   // Encryption setup flow
   const [showEncryptionSetup, setShowEncryptionSetup] = useState(false)
@@ -354,6 +356,23 @@ export function CloudSyncPanel({
       onError('Sync failed')
     } finally {
       setSyncing(false)
+    }
+  }
+
+  const handleReconnect = async () => {
+    setReconnecting(true)
+    try {
+      const response = await chrome.runtime.sendMessage({ type: 'CLOUD_RECONNECT' })
+      if (response.success) {
+        onSuccess('Reconnected to Google Drive')
+        loadStatus()
+      } else {
+        onError(response.error || 'Reconnect failed')
+      }
+    } catch {
+      onError('Reconnect failed')
+    } finally {
+      setReconnecting(false)
     }
   }
 
@@ -940,7 +959,7 @@ export function CloudSyncPanel({
               </span>
               <button
                 onClick={handleSync}
-                disabled={syncing || status.syncing || !status.unlocked}
+                disabled={syncing || status.syncing || !status.unlocked || reconnecting}
                 class="px-3 py-1 text-sm bg-raft-600 text-white rounded hover:bg-raft-700 disabled:opacity-50"
               >
                 {syncing ? 'Syncing...' : 'Sync Now'}
@@ -954,9 +973,20 @@ export function CloudSyncPanel({
             )}
 
             {status.lastError && (
-              <p role="alert" class="text-xs text-red-600">
-                Last error: {status.lastError}
-              </p>
+              <div class="flex items-center justify-between gap-2">
+                <p role="alert" class="text-xs text-red-600">
+                  Last error: {status.lastError}
+                </p>
+                {status.authExpired && (
+                  <button
+                    onClick={handleReconnect}
+                    disabled={reconnecting}
+                    class="shrink-0 px-3 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+                  >
+                    {reconnecting ? 'Reconnecting...' : 'Reconnect'}
+                  </button>
+                )}
+              </div>
             )}
           </div>
 

--- a/src/shared/cloudSync/index.ts
+++ b/src/shared/cloudSync/index.ts
@@ -52,6 +52,7 @@ export {
 
 // OAuth
 export {
+  OAuthError,
   launchGoogleOAuth,
   refreshAccessToken,
   revokeAccess,

--- a/src/shared/cloudSync/oauth.ts
+++ b/src/shared/cloudSync/oauth.ts
@@ -9,6 +9,19 @@ import type { CloudTokens } from './types'
 import { GOOGLE_OAUTH } from '../constants'
 
 /**
+ * OAuth error with machine-readable error code (e.g., "invalid_grant")
+ */
+export class OAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly errorCode: string
+  ) {
+    super(message)
+    this.name = 'OAuthError'
+  }
+}
+
+/**
  * Result of the OAuth flow
  */
 export interface OAuthResult {
@@ -176,7 +189,10 @@ export async function refreshAccessToken(refreshToken: string): Promise<CloudTok
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}))
-    throw new Error(`Token refresh failed: ${errorData.error_description || response.statusText}`)
+    throw new OAuthError(
+      `Token refresh failed: ${errorData.error_description || response.statusText}`,
+      errorData.error || 'unknown'
+    )
   }
 
   const data = await response.json()

--- a/src/shared/cloudSync/syncEngine.ts
+++ b/src/shared/cloudSync/syncEngine.ts
@@ -29,7 +29,8 @@ import {
   decrypt,
   createVerificationHash,
 } from './encryption'
-import { getValidTokens } from './oauth'
+import { OAuthError, getValidTokens } from './oauth'
+import { DriveApiError } from './providers/gdrive'
 import * as gdrive from './providers/gdrive'
 import * as syncQueue from './syncQueue'
 import { sessionsStorage } from '../storage'
@@ -63,6 +64,22 @@ function withManifestLock<T>(fn: () => Promise<T>): Promise<T> {
     () => {}
   )
   return result
+}
+
+/**
+ * Check if an error indicates expired/revoked auth tokens
+ */
+function isAuthError(error: unknown): boolean {
+  if (error instanceof OAuthError && error.errorCode === 'invalid_grant') return true
+  if (error instanceof DriveApiError && error.status === 401) return true
+  return false
+}
+
+/**
+ * Clear cached tokens (used after reconnect to force re-decryption of new tokens)
+ */
+export function clearCachedTokens(): void {
+  cachedTokens = null
 }
 
 /** Save the set of cloud-synced session IDs to local storage */
@@ -394,6 +411,7 @@ export async function performFullSync(): Promise<SyncResult> {
       syncing: false,
       lastSyncAt: Date.now(),
       lastError: result.errors.length > 0 ? result.errors[0] : undefined,
+      authExpired: false,
       currentOperation: undefined,
     })
 
@@ -406,6 +424,7 @@ export async function performFullSync(): Promise<SyncResult> {
     await syncStateStorage.update({
       syncing: false,
       lastError: errorMessage,
+      authExpired: isAuthError(error) ? true : undefined,
       currentOperation: undefined,
     })
   }
@@ -472,6 +491,10 @@ export async function pushSession(sessionId: string): Promise<void> {
     })
   } catch (error) {
     console.error('[Raft Sync] Failed to push session:', error)
+    if (isAuthError(error)) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      await syncStateStorage.update({ authExpired: true, lastError: errorMessage })
+    }
     await syncQueue.enqueueUpload(sessionId)
   }
 }
@@ -549,6 +572,12 @@ export async function processQueue(): Promise<void> {
 
       await syncQueue.markComplete(item.id)
     } catch (error) {
+      if (isAuthError(error)) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        await syncStateStorage.update({ authExpired: true, lastError: errorMessage })
+        await syncQueue.markFailed(item.id, String(error))
+        break
+      }
       await syncQueue.markFailed(item.id, String(error))
     }
 
@@ -566,6 +595,7 @@ export async function getSyncStatus(): Promise<{
   syncing: boolean
   lastSyncAt?: number
   lastError?: string
+  authExpired?: boolean
   pendingCount: number
   email?: string
 }> {
@@ -581,6 +611,7 @@ export async function getSyncStatus(): Promise<{
     syncing: state.syncing,
     lastSyncAt: state.lastSyncAt,
     lastError: state.lastError,
+    authExpired: state.authExpired,
     pendingCount: state.pendingCount,
     email: credentials?.email,
   }

--- a/src/shared/cloudSync/types.ts
+++ b/src/shared/cloudSync/types.ts
@@ -130,6 +130,8 @@ export interface SyncState {
   lastSyncAt?: number
   /** Last sync error */
   lastError?: string
+  /** Whether auth tokens are expired/revoked (requires reconnect) */
+  authExpired?: boolean
   /** Number of pending operations */
   pendingCount: number
   /** Current operation description */

--- a/tests/unit/syncEngine.test.ts
+++ b/tests/unit/syncEngine.test.ts
@@ -21,11 +21,14 @@ import {
   getValidTokensForDisconnect,
   getEncryptionKeyForSetup,
   setEncryptionKey,
+  clearCachedTokens,
 } from '@/shared/cloudSync/syncEngine'
 import * as gdrive from '@/shared/cloudSync/providers/gdrive'
 import * as syncQueue from '@/shared/cloudSync/syncQueue'
 import * as encryption from '@/shared/cloudSync/encryption'
 import * as oauth from '@/shared/cloudSync/oauth'
+import { OAuthError } from '@/shared/cloudSync/oauth'
+import { DriveApiError } from '@/shared/cloudSync/providers/gdrive'
 import {
   cloudCredentialsStorage,
   encryptionKeyStorage,
@@ -38,10 +41,33 @@ import { CLOUD_SYNC_KEYS } from '@/shared/constants'
 import type { CloudCredentials, EncryptionKeyData, CloudTokens, SyncManifest, SyncSessionMeta } from '@/shared/cloudSync/types'
 import type { Session } from '@/shared/types'
 
-// Mock modules
-vi.mock('@/shared/cloudSync/providers/gdrive')
+// Mock modules (partial mocks to preserve error classes for instanceof checks)
+vi.mock('@/shared/cloudSync/providers/gdrive', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/cloudSync/providers/gdrive')>()
+  return {
+    ...actual,
+    downloadManifest: vi.fn(),
+    uploadManifest: vi.fn(),
+    downloadSession: vi.fn(),
+    uploadSession: vi.fn(),
+    deleteSession: vi.fn(),
+    downloadKeyData: vi.fn(),
+    uploadKeyData: vi.fn(),
+    clearAllData: vi.fn(),
+  }
+})
 vi.mock('@/shared/cloudSync/syncQueue')
-vi.mock('@/shared/cloudSync/oauth')
+vi.mock('@/shared/cloudSync/oauth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/cloudSync/oauth')>()
+  return {
+    ...actual,
+    getValidTokens: vi.fn(),
+    refreshAccessToken: vi.fn(),
+    launchGoogleOAuth: vi.fn(),
+    revokeAccess: vi.fn(),
+    tokensNeedRefresh: vi.fn(),
+  }
+})
 
 // Mock fetch for encryption tests
 const mockFetch = vi.fn()
@@ -1096,6 +1122,84 @@ describe('syncEngine - integration scenarios', () => {
 
       expect(isUnlocked()).toBe(true)
       expect(getEncryptionKeyForSetup()).toBe(key)
+    })
+  })
+
+  describe('auth error detection', () => {
+    beforeEach(async () => {
+      await unlock('test-password')
+      vi.mocked(syncQueue.getNextItem).mockResolvedValue(null)
+    })
+
+    it('should set authExpired when OAuthError with invalid_grant is thrown', async () => {
+      vi.mocked(oauth.getValidTokens).mockRejectedValue(
+        new OAuthError('Token has been expired or revoked.', 'invalid_grant')
+      )
+
+      const result = await performFullSync()
+
+      expect(result.success).toBe(false)
+      const state = await syncStateStorage.get()
+      expect(state.authExpired).toBe(true)
+    })
+
+    it('should set authExpired when DriveApiError with 401 is thrown', async () => {
+      // Let tokens pass but fail on the drive call
+      vi.mocked(oauth.getValidTokens).mockResolvedValue(testTokens)
+      vi.mocked(gdrive.downloadManifest).mockRejectedValue(
+        new DriveApiError('Unauthorized', 401)
+      )
+
+      const result = await performFullSync()
+
+      expect(result.success).toBe(false)
+      const state = await syncStateStorage.get()
+      expect(state.authExpired).toBe(true)
+    })
+
+    it('should clear authExpired on successful sync', async () => {
+      // Pre-set authExpired
+      await syncStateStorage.update({ authExpired: true })
+
+      vi.mocked(oauth.getValidTokens).mockResolvedValue(testTokens)
+      vi.mocked(gdrive.downloadManifest).mockResolvedValue(null)
+      vi.mocked(gdrive.uploadManifest).mockResolvedValue()
+
+      const result = await performFullSync()
+
+      expect(result.success).toBe(true)
+      const state = await syncStateStorage.get()
+      expect(state.authExpired).toBe(false)
+    })
+
+    it('should not set authExpired for non-auth errors', async () => {
+      vi.mocked(oauth.getValidTokens).mockResolvedValue(testTokens)
+      vi.mocked(gdrive.downloadManifest).mockRejectedValue(new Error('Network error'))
+
+      const result = await performFullSync()
+
+      expect(result.success).toBe(false)
+      const state = await syncStateStorage.get()
+      expect(state.authExpired).toBeUndefined()
+    })
+
+    it('should include authExpired in getSyncStatus', async () => {
+      await syncStateStorage.update({ authExpired: true })
+
+      const status = await getSyncStatus()
+      expect(status.authExpired).toBe(true)
+    })
+  })
+
+  describe('clearCachedTokens', () => {
+    it('should clear cached tokens so next getTokens re-decrypts', async () => {
+      await unlock('test-password')
+
+      // Calling clearCachedTokens should not throw
+      clearCachedTokens()
+
+      // Engine should still be unlocked (encryption key not cleared)
+      expect(isUnlocked()).toBe(true)
     })
   })
 })


### PR DESCRIPTION
When Google OAuth refresh tokens expire or are revoked, sync now detects the auth failure and shows a "Reconnect" button instead of a dead-end error. The reconnect launches a fresh OAuth flow and saves new tokens without losing the encryption setup.