### PR TITLE
Add tab hibernation on browser startup

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1545,8 +1545,33 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 /**
  * Handle service worker startup (wake from termination)
  */
-chrome.runtime.onStartup.addListener(() => {
+chrome.runtime.onStartup.addListener(async () => {
   // Don't call initialize() here - it runs at the bottom of the script
+  await initReady
+  const settings = await settingsStorage.get()
+  if (settings.suspension.hibernateOnStartup) {
+    console.log('[Raft] Hibernate on startup enabled, suspending all tabs')
+    const windows = await chrome.windows.getAll()
+    for (const win of windows) {
+      if (!win.id) continue
+      // We need a Raft extension page as the active tab so chrome.tabs.discard()
+      // can suspend the user's previously-active tab. Reuse one if already open.
+      const extensionOrigin = chrome.runtime.getURL('')
+      const winTabs = await chrome.tabs.query({ windowId: win.id })
+      const raftTab = winTabs.find((t) => t.url?.startsWith(extensionOrigin))
+      if (raftTab?.id) {
+        await chrome.tabs.update(raftTab.id, { active: true })
+      } else {
+        await chrome.tabs.create({
+          url: chrome.runtime.getURL('src/options/index.html#sessions'),
+          active: true,
+          windowId: win.id,
+        })
+      }
+      const count = await suspendOtherTabs(win.id)
+      console.log(`[Raft] Hibernated ${count} tabs in window ${win.id}`)
+    }
+  }
 })
 
 // Handle keyboard commands

--- a/src/background/suspension.ts
+++ b/src/background/suspension.ts
@@ -151,23 +151,20 @@ export async function suspendOtherTabs(windowId?: number): Promise<number> {
 }
 
 /**
- * Suspend all tabs across all windows (including active tabs when possible)
+ * Suspend all non-active tabs across all windows.
+ * Active tabs are skipped because chrome.tabs.discard() cannot discard the active tab.
+ * For startup hibernation (which needs to suspend active tabs too), the onStartup
+ * handler opens a Raft page as the active tab first, then uses suspendOtherTabs().
  */
 export async function suspendAllTabs(): Promise<number> {
   const windows = await chrome.windows.getAll({ populate: true })
   const settings = await settingsStorage.get()
-
   let suspended = 0
 
   for (const win of windows) {
     if (!win.id || !win.tabs) continue
-
-    const activeTab = win.tabs.find((t) => t.active)
-    const otherTabs = win.tabs.filter((t) => !t.active)
-
-    // First, suspend all non-active tabs
-    for (const tab of otherTabs) {
-      if (tab.id) {
+    for (const tab of win.tabs) {
+      if (tab.id && !tab.active) {
         const check = await canSuspendTab(tab, settings)
         if (check.canSuspend) {
           const success = await suspendTab(tab.id)
@@ -175,23 +172,9 @@ export async function suspendAllTabs(): Promise<number> {
         }
       }
     }
-
-    // Now handle the active tab if it's suspendable
-    if (activeTab?.id) {
-      const check = await canSuspendTab(activeTab, settings)
-      if (check.canSuspend) {
-        // Find a tab to switch to (prefer already-discarded tabs)
-        const switchTarget = win.tabs.find((t) => t.id !== activeTab.id && t.id !== undefined)
-        if (switchTarget?.id) {
-          // Activate another tab first, then suspend the previously active one
-          await chrome.tabs.update(switchTarget.id, { active: true })
-          const success = await suspendTab(activeTab.id)
-          if (success) suspended++
-        }
-      }
-    }
   }
 
+  console.log(`[Raft] Suspended ${suspended} tabs across all windows`)
   return suspended
 }
 

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -45,7 +45,11 @@ function formatDate(timestamp: number): string {
 export function App() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS)
   const [loading, setLoading] = useState(true)
-  const [activeTab, setActiveTab] = useState<TabType>('general')
+  const [activeTab, setActiveTab] = useState<TabType>(() => {
+    const hash = globalThis.location?.hash?.slice(1)
+    const validTabs: TabType[] = ['general', 'sessions', 'browser-sync', 'cloud', 'about', 'dev']
+    return validTabs.includes(hash as TabType) ? (hash as TabType) : 'general'
+  })
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
   const [isPro, setIsPro] = useState(false) // Checked asynchronously via checkProStatus()
   const [syncStatus, setSyncStatus] = useState<{
@@ -695,6 +699,22 @@ export function App() {
 
                     {/* Form detection feature hidden until implemented */}
                   </div>
+
+                  <label class="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      checked={settings.suspension.hibernateOnStartup}
+                      onChange={(e) =>
+                        handleSettingChange({
+                          suspension: {
+                            hibernateOnStartup: (e.target as HTMLInputElement).checked,
+                          },
+                        })
+                      }
+                      class="w-4 h-4 rounded border-raft-300 text-raft-600 focus:ring-raft-500"
+                    />
+                    <span class="text-raft-700">Hibernate tabs when browser starts</span>
+                  </label>
                 </div>
               </section>
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -126,6 +126,8 @@ export interface Settings {
     neverSuspendForms: boolean
     /** URL patterns to whitelist (never suspend) */
     whitelist: string[]
+    /** Hibernate all restored tabs immediately when Chrome starts */
+    hibernateOnStartup: boolean
   }
   /** Auto-save settings */
   autoSave: {
@@ -167,6 +169,7 @@ export const DEFAULT_SETTINGS: Settings = {
     neverSuspendAudio: true,
     neverSuspendForms: true,
     whitelist: [],
+    hibernateOnStartup: false,
   },
   autoSave: {
     enabled: false,

--- a/tests/integration/suspension-flow.test.ts
+++ b/tests/integration/suspension-flow.test.ts
@@ -118,7 +118,7 @@ describe('Suspension Flow Integration', () => {
       expect(tabs.find((t) => t.id === 4)?.discarded).toBe(false)
     })
 
-    it('should suspend all tabs across all windows including active tabs', async () => {
+    it('should suspend non-active tabs across all windows, skipping active tabs', async () => {
       addMockTab({ id: 1, windowId: 1, url: 'https://w1-active.com', active: true })
       addMockTab({ id: 2, windowId: 1, url: 'https://w1-other.com', active: false })
       addMockTab({ id: 3, windowId: 2, url: 'https://w2-active.com', active: true })
@@ -126,14 +126,15 @@ describe('Suspension Flow Integration', () => {
 
       const count = await suspendAllTabs()
 
-      expect(count).toBe(4) // All tabs including previously active ones
+      expect(count).toBe(2) // Only non-active tabs
 
       const tabs = getMockTabs()
 
-      // All tabs should be suspended
-      expect(tabs.find((t) => t.id === 1)?.discarded).toBe(true)
+      // Active tabs should NOT be suspended
+      expect(tabs.find((t) => t.id === 1)?.discarded).toBe(false)
+      expect(tabs.find((t) => t.id === 3)?.discarded).toBe(false)
+      // Non-active tabs should be suspended
       expect(tabs.find((t) => t.id === 2)?.discarded).toBe(true)
-      expect(tabs.find((t) => t.id === 3)?.discarded).toBe(true)
       expect(tabs.find((t) => t.id === 4)?.discarded).toBe(true)
     })
 

--- a/tests/unit/suspension.test.ts
+++ b/tests/unit/suspension.test.ts
@@ -680,7 +680,7 @@ describe('suspendOtherTabs', () => {
 })
 
 describe('suspendAllTabs', () => {
-  it('should suspend all tabs including active (switch-then-suspend path)', async () => {
+  it('should suspend non-active tabs and skip active tabs', async () => {
     const win = addMockWindow({ id: 20, focused: true })
 
     addMockTab({
@@ -704,10 +704,11 @@ describe('suspendAllTabs', () => {
 
     const count = await suspendAllTabs()
 
-    expect(count).toBe(2)
+    expect(count).toBe(1)
 
     const tabs = getMockTabs()
-    expect(tabs.find((t) => t.id === 201)?.discarded).toBe(true)
+    // Active tab should NOT be discarded
+    expect(tabs.find((t) => t.id === 201)?.discarded).toBe(false)
     expect(tabs.find((t) => t.id === 202)?.discarded).toBe(true)
   })
 


### PR DESCRIPTION
## Summary
- Adds a "Hibernate tabs when browser starts" setting that suspends all restored tabs when Chrome launches
- On startup, opens a Raft extension page as the active tab in each window so `chrome.tabs.discard()` can suspend the user's previously-active tabs
- Simplifies `suspendAllTabs()` to only handle non-active tabs (active tab handling moved to the startup-specific code path)
- Options page reads URL hash on load to support deep linking (e.g. `#sessions`)

## Test plan
- [ ] Enable "Hibernate tabs when browser starts" in options → General
- [ ] Restart Chrome and verify all tabs are suspended on launch
- [ ] Verify `pnpm test` passes
- [ ] Verify `pnpm typecheck` passes