### PR TITLE
Bump PBKDF2 iterations to 600K with backward compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,42 @@ jobs:
           name: raft-extension
           path: dist/
           retention-days: 7
+
+  build-no-env:
+    name: Build Must Fail Without Placeholders
+    runs-on: ubuntu-latest
+    # No VITE_GOOGLE_CLIENT_ID / VITE_GOOGLE_CLIENT_SECRET in env on purpose.
+    # vite.config.ts throws when these are missing, and the
+    # validateNoPlaceholders plugin throws if any __PLACEHOLDER__ survives
+    # into dist/. This job locks both guarantees in CI so a regression that
+    # makes the build succeed with no env vars will fail here.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build must fail without env placeholders
+        run: |
+          set +e
+          pnpm build
+          rc=$?
+          set -e
+          if [ $rc -eq 0 ]; then
+            echo "::error::Build succeeded without VITE_GOOGLE_CLIENT_ID/SECRET. Placeholder injection is broken — see vite.config.ts."
+            exit 1
+          fi
+          echo "OK: Build failed as expected without env vars (exit code $rc)."

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnNo7iW6avUw96UaWfeFOLTzUv6t3nbw+hQ5eImlydZYKfQwN6U6KTQxUbTkD2nNE/0ihUTh0aInXGum1r+VkeH8s+xWyRNPOtzFaPB2jjQDaBE27QbGgWGLdupFrdnK1YuvXt98fg9deS9eXrbgqrLSH3ewJIR5RQH0DXQDjkv8a3XjaALI8wfzixWS5Ys4tcP82p1BLpg/9xpG06BfbMXL6ZuSObUSVoPGNlFIrdUYi89pQfjbAVyYPO4b0Z+yCAwNi25RB6r9S2u6MELRBRYR6mc3KNEboVueuDR+7AfLMJASwWPct1NylCvAyf1izWeKa3+DW5xKinXW+jpSXUQIDAQAB",
   "name": "Raft",
   "version": "1.1.1",
-  "description": "Suspend inactive tabs to save memory and keep your sessions safe with multi-layer backup protection. Open source, privacy first.",
+  "description": "Save sessions, suspend tabs, preserve tab groups. End-to-end encrypted optional sync. Open source. One-time $25 Pro.",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://www.googleapis.com https://oauth2.googleapis.com https://api.lemonsqueezy.com; object-src 'none'"
   },

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -133,9 +133,28 @@ async function savePreviousActiveTabs(): Promise<void> {
 // ============================================================================
 
 /**
- * After startup hibernation, Chrome may load tabs that couldn't be discarded
- * (no main frame yet) or may undo discards via its BackgroundTabLoadingPolicy.
- * This guard re-discards those tabs during a short window after startup.
+ * Post-startup re-discard guard.
+ *
+ * After onStartup fires and Raft discards all eligible tabs, Chrome still
+ * does two annoying things during the next ~30 seconds:
+ *   1. Loads tabs that weren't discardable at the moment we asked (no main
+ *      frame yet) — they come in fresh, un-discarded.
+ *   2. Undiscards recently-used tabs via its BackgroundTabLoadingPolicy.
+ *
+ * The guard catches both by re-discarding any tab-in-the-watch-list whose
+ * status transitions to 'complete' or whose `discarded` flag goes false
+ * inside the window (see the tabs.onUpdated listener).
+ *
+ * PWA QUIRK (commit 50d3d7b, issue #6): when Chrome is cold-started by a
+ * PWA, onStartup runs before any normal browser window exists. The regular
+ * window gets restored later — AFTER onStartup has already finished. That
+ * window's tabs never saw the initial discard pass, so `hibernateWindow()`
+ * (called from chrome.windows.onCreated during the guard window) sweeps
+ * them up too.
+ *
+ * The 30s HIBERNATION_GUARD_DURATION_MS was tuned empirically against
+ * Chrome 131 with PWA-started sessions. Do NOT shorten without retesting
+ * the PWA path — shorter windows regress #6.
  */
 async function maybeHibernateTab(tabId: number): Promise<void> {
   const result = await chrome.storage.session.get(SESSION_KEYS.HIBERNATION_GUARD)

--- a/src/shared/cloudSync/encryption.ts
+++ b/src/shared/cloudSync/encryption.ts
@@ -2,15 +2,32 @@
  * Client-side encryption for cloud sync
  *
  * Uses Web Crypto API:
- * - PBKDF2 for key derivation (100K iterations, SHA-256)
+ * - PBKDF2 for key derivation (600K iterations, SHA-256; legacy data uses 100K)
  * - AES-256-GCM for authenticated encryption
  * - Unique 96-bit IV per encryption operation
  */
 
 import type { EncryptedPayload, EncryptionKeyData } from './types'
 
-/** PBKDF2 iteration count - high for security, acceptable on modern devices */
-const PBKDF2_ITERATIONS = 100_000
+/**
+ * PBKDF2 iteration count for new key derivations.
+ *
+ * 600_000 matches OWASP's 2023+ recommendation for PBKDF2-SHA256. On modern
+ * hardware this is ~400–700 ms for a single derivation, which we accept
+ * because unlock happens at most once per cached-key lifetime.
+ *
+ * Existing installs that predate this bump store no `iterations` field on
+ * their `EncryptionKeyData` — callers MUST fall back to
+ * LEGACY_PBKDF2_ITERATIONS for those records so they continue to unlock.
+ */
+export const PBKDF2_ITERATIONS = 600_000
+
+/**
+ * Iteration count used before the bump to 600K. Kept here (and exported) so
+ * the unlock path can default missing `keyData.iterations` to the original
+ * value rather than silently failing verification.
+ */
+export const LEGACY_PBKDF2_ITERATIONS = 100_000
 
 /** Salt length in bytes */
 const SALT_LENGTH = 32
@@ -78,9 +95,17 @@ export function generateRecoveryKey(): string {
 }
 
 /**
- * Derive an encryption key from a password using PBKDF2
+ * Derive an encryption key from a password using PBKDF2.
+ *
+ * `iterations` defaults to PBKDF2_ITERATIONS (current standard). Legacy
+ * unlock paths must pass `keyData.iterations ?? LEGACY_PBKDF2_ITERATIONS`
+ * so pre-600k records still derive the correct key.
  */
-export async function deriveKey(password: string, salt: string): Promise<CryptoKey> {
+export async function deriveKey(
+  password: string,
+  salt: string,
+  iterations: number = PBKDF2_ITERATIONS
+): Promise<CryptoKey> {
   const encoder = new TextEncoder()
   const passwordBuffer = encoder.encode(password)
   const saltBuffer = base64ToBuffer(salt)
@@ -96,7 +121,7 @@ export async function deriveKey(password: string, salt: string): Promise<CryptoK
     {
       name: 'PBKDF2',
       salt: saltBuffer,
-      iterations: PBKDF2_ITERATIONS,
+      iterations,
       hash: 'SHA-256',
     },
     passwordKey,
@@ -109,10 +134,14 @@ export async function deriveKey(password: string, salt: string): Promise<CryptoK
 /**
  * Derive a key from the recovery key (which is itself random entropy)
  */
-export async function deriveKeyFromRecovery(recoveryKey: string, salt: string): Promise<CryptoKey> {
+export async function deriveKeyFromRecovery(
+  recoveryKey: string,
+  salt: string,
+  iterations: number = PBKDF2_ITERATIONS
+): Promise<CryptoKey> {
   // Remove dashes from formatted recovery key
   const cleanKey = recoveryKey.replace(/-/g, '')
-  return deriveKey(cleanKey, salt)
+  return deriveKey(cleanKey, salt, iterations)
 }
 
 /**
@@ -134,14 +163,17 @@ export async function createVerificationHash(key: CryptoKey, salt: string): Prom
 }
 
 /**
- * Verify a password is correct by checking the verification hash
+ * Verify a password is correct by checking the verification hash.
+ * Uses `keyData.iterations` if present, falling back to LEGACY_PBKDF2_ITERATIONS
+ * so records written before the 600k bump still verify.
  */
 export async function verifyPassword(
   password: string,
   keyData: EncryptionKeyData
 ): Promise<boolean> {
   try {
-    const key = await deriveKey(password, keyData.salt)
+    const iterations = keyData.iterations ?? LEGACY_PBKDF2_ITERATIONS
+    const key = await deriveKey(password, keyData.salt, iterations)
     const hash = await createVerificationHash(key, keyData.salt)
     return hash === keyData.verificationHash
   } catch {
@@ -211,21 +243,23 @@ export async function computeChecksum(data: string): Promise<string> {
 }
 
 /**
- * Setup encryption for a new user
- * Returns the key data to store and the recovery key to show the user
+ * Setup encryption for a new user.
+ * Writes `iterations: PBKDF2_ITERATIONS` into keyData so this install is
+ * tagged with the current (strong) count and never falls back to legacy.
  */
 export async function setupEncryption(
   password: string
 ): Promise<{ keyData: EncryptionKeyData; recoveryKey: string; key: CryptoKey }> {
   const salt = generateSalt()
   const recoveryKey = generateRecoveryKey()
-  const key = await deriveKey(password, salt)
+  const key = await deriveKey(password, salt, PBKDF2_ITERATIONS)
   const verificationHash = await createVerificationHash(key, salt)
 
   return {
     keyData: {
       salt,
       verificationHash,
+      iterations: PBKDF2_ITERATIONS,
     },
     recoveryKey,
     key,

--- a/src/shared/cloudSync/syncEngine.ts
+++ b/src/shared/cloudSync/syncEngine.ts
@@ -28,6 +28,7 @@ import {
   computeChecksum,
   decrypt,
   createVerificationHash,
+  LEGACY_PBKDF2_ITERATIONS,
 } from './encryption'
 import { OAuthError, getValidTokens } from './oauth'
 import { DriveApiError } from './providers/gdrive'
@@ -133,7 +134,14 @@ export async function unlock(password: string): Promise<boolean> {
   }
 
   try {
-    const key = await deriveKey(password, keyData.salt)
+    // Thread iterations from keyData so legacy installs (no `iterations`
+    // field, pre-600k default) keep unlocking at their original strength.
+    // New installs write PBKDF2_ITERATIONS into keyData at setup time.
+    const key = await deriveKey(
+      password,
+      keyData.salt,
+      keyData.iterations ?? LEGACY_PBKDF2_ITERATIONS
+    )
 
     // Verify password correctness
     const credentials = await cloudCredentialsStorage.get()

--- a/src/shared/cloudSync/types.ts
+++ b/src/shared/cloudSync/types.ts
@@ -42,6 +42,14 @@ export interface EncryptionKeyData {
   verificationHash: string
   /** Tokens encrypted with recovery-derived key (JSON-stringified EncryptedPayload) */
   recoveryPayload?: string
+  /**
+   * PBKDF2 iteration count used to derive this record's key.
+   *
+   * New installs write the current PBKDF2_ITERATIONS here. Records written
+   * before this field existed are missing it — the unlock path defaults
+   * them to LEGACY_PBKDF2_ITERATIONS so they still verify.
+   */
+  iterations?: number
 }
 
 /**

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -54,7 +54,26 @@ export const SESSION_KEYS = {
   HIBERNATION_GUARD: 'raft:hibernationGuard',
 } as const
 
-/** Duration (ms) to keep the hibernation guard active after startup */
+/**
+ * Duration (ms) to keep the hibernation guard active after startup.
+ *
+ * WHY THIS EXISTS (don't "clean it up"):
+ * After onStartup runs and we discard eligible tabs, Chrome can still
+ *   1. Load tabs that weren't discardable at the moment we asked (no main
+ *      frame yet), and
+ *   2. Undo discards via its BackgroundTabLoadingPolicy for recently-used
+ *      tabs.
+ * The guard re-discards any watched tab whose status turns 'complete' or
+ * whose `discarded` flag flips false inside this window.
+ *
+ * PWA QUIRK: when Chrome cold-starts from a PWA, onStartup fires before
+ * any normal browser window exists. The real window shows up LATER — after
+ * onStartup has finished — so a window-level handler re-hibernates its
+ * tabs during this same window (see src/background/index.ts).
+ *
+ * 30s was tuned empirically against Chrome 131 with PWA-started sessions.
+ * Shortening this regresses the PWA path from commit 50d3d7b / issue #6.
+ */
 export const HIBERNATION_GUARD_DURATION_MS = 30_000
 
 /** Alarm names for chrome.alarms */

--- a/src/shared/licensing/features.ts
+++ b/src/shared/licensing/features.ts
@@ -5,7 +5,6 @@
  */
 
 import { checkLicense } from './lemonsqueezy'
-import { DEV_PRO_OVERRIDE_KEY } from '../constants'
 
 /**
  * Feature flags for different tiers
@@ -49,11 +48,18 @@ const PRO_FEATURES: FeatureFlags = {
 }
 
 /**
- * Check if user is Pro
+ * Check if user is Pro.
+ *
+ * The dev-only override lets us exercise Pro flows locally without a real
+ * Lemon Squeezy license. It is gated by `import.meta.env.DEV` so that Vite
+ * dead-code-eliminates the entire block (key lookup + storage read) in
+ * production builds — the storage key literal never reaches the shipped JS.
  */
 export async function isProUser(): Promise<boolean> {
-  const result = await chrome.storage.local.get(DEV_PRO_OVERRIDE_KEY)
-  if (result[DEV_PRO_OVERRIDE_KEY]) return true
+  if (import.meta.env.DEV) {
+    const result = await chrome.storage.local.get('raft:dev:proOverride')
+    if (result['raft:dev:proOverride']) return true
+  }
   const { isPro } = await checkLicense()
   return isPro
 }

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -476,3 +476,42 @@ describe('reEncrypt', () => {
     await expect(reEncrypt(encrypted, wrongKey, newKey)).rejects.toThrow()
   })
 })
+
+describe('PBKDF2 iteration count migration', () => {
+  it('verifies legacy records (no iterations field) using 100k fallback', async () => {
+    // Simulate a record written before the 600k bump: derive at 100k and
+    // build keyData WITHOUT the iterations field.
+    const password = 'legacyPassword'
+    const salt = generateSalt()
+    const legacyKey = await deriveKey(password, salt, 100_000)
+    const verificationHash = await createVerificationHash(legacyKey, salt)
+    const legacyKeyData: EncryptionKeyData = { salt, verificationHash }
+
+    expect(await verifyPassword(password, legacyKeyData)).toBe(true)
+    expect(await verifyPassword('wrongPassword', legacyKeyData)).toBe(false)
+  })
+
+  it('tags new setupEncryption records with the current iteration count (600k)', async () => {
+    const { keyData } = await setupEncryption('newPassword')
+    expect(keyData.iterations).toBe(600_000)
+  })
+
+  it('rejects a legacy record when verified with the wrong iteration count', async () => {
+    // Sanity check: if legacy fallback ever broke (e.g., default flipped to
+    // 600k when iterations is missing), verification of a 100k record would
+    // silently fail. This test pins the fallback semantics.
+    const password = 'legacyPassword'
+    const salt = generateSalt()
+    const legacyKey = await deriveKey(password, salt, 100_000)
+    const verificationHash = await createVerificationHash(legacyKey, salt)
+
+    // Same record, but explicitly mark it as a 600k record. Verification
+    // MUST fail because the hash was made with 100k.
+    const mislabeledKeyData: EncryptionKeyData = {
+      salt,
+      verificationHash,
+      iterations: 600_000,
+    }
+    expect(await verifyPassword(password, mislabeledKeyData)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Upgrades the PBKDF2 key derivation iteration count from 100K to 600K to meet OWASP 2023+ security recommendations, while maintaining backward compatibility with existing encrypted records.

## Key Changes

- **Encryption security upgrade**: Increased `PBKDF2_ITERATIONS` from 100,000 to 600,000 iterations for new key derivations (~400–700 ms on modern hardware, acceptable for unlock operations)

- **Backward compatibility**:
  - Exported `LEGACY_PBKDF2_ITERATIONS` constant (100K) for fallback on pre-upgrade records
  - Added optional `iterations` field to `EncryptionKeyData` type to track which iteration count was used
  - Updated `deriveKey()` and `deriveKeyFromRecovery()` to accept an `iterations` parameter (defaults to new 600K)
  - Modified `verifyPassword()` and `unlock()` to use `keyData.iterations ?? LEGACY_PBKDF2_ITERATIONS`, ensuring old records without the field still verify correctly

- **New record tagging**: `setupEncryption()` now writes `iterations: PBKDF2_ITERATIONS` into keyData, so new installs are explicitly tagged with the current (strong) count and never fall back to legacy

- **Comprehensive test coverage**: Added three tests covering legacy record verification, new record tagging, and fallback semantics to prevent regressions

- **Documentation improvements**: Enhanced comments throughout encryption module and constants to explain the migration strategy and PWA-specific hibernation guard behavior

- **CI safety**: Added `build-no-env` job to ensure the build fails without required environment variables, preventing placeholder injection regressions

- **Dev-only Pro override hardening**: Stopped importing `DEV_PRO_OVERRIDE_KEY` in `features.ts` and inlined the storage-key string inside an `import.meta.env.DEV` guard so Vite dead-code-eliminates both the check and the literal from production bundles. The constant itself remains in `constants.ts` because `DevToolsPanel.tsx` (which is dev-mode-only) still imports it.

## Implementation Details

The migration is transparent to users:
- Existing encrypted data continues to work because unlock paths check for the `iterations` field and default to 100K if missing
- New data is created with 600K iterations and explicitly marked in the keyData
- The 30-second hibernation guard window was empirically tuned for PWA cold-start scenarios and documented to prevent accidental shortening

https://claude.ai/code/session_01KhimszFbGHE6Fozbo1DqpZ