### PR TITLE
refactor: introduce browser.* adapter for chrome.*

### DIFF
--- a/src/background/deduplication.ts
+++ b/src/background/deduplication.ts
@@ -10,6 +10,7 @@
 import { settingsStorage } from '@/shared/storage'
 import { PROTECTED_URL_PATTERNS } from '@/shared/constants'
 import { normalizeUrlForDedup } from '@/shared/utils'
+import { browser } from '@/shared/browser'
 
 export interface DuplicateResult {
   /** Total duplicate tabs found (including the one kept) */
@@ -23,7 +24,7 @@ export interface DuplicateResult {
 /**
  * Check if a tab is protected from closure during dedup.
  */
-async function isProtected(tab: chrome.tabs.Tab): Promise<boolean> {
+async function isProtected(tab: browser.tabs.Tab): Promise<boolean> {
   // Protected URL patterns (chrome://, etc.)
   if (tab.url && PROTECTED_URL_PATTERNS.some((pattern) => tab.url!.startsWith(pattern))) {
     return true
@@ -47,7 +48,7 @@ async function isProtected(tab: chrome.tabs.Tab): Promise<boolean> {
 /**
  * Score a tab for keep priority (higher = more likely to keep).
  */
-function tabKeepScore(tab: chrome.tabs.Tab): number {
+function tabKeepScore(tab: browser.tabs.Tab): number {
   let score = 0
   if (tab.active) score += 1000
   if (!tab.discarded) score += 100
@@ -60,9 +61,9 @@ function tabKeepScore(tab: chrome.tabs.Tab): number {
  * Returns a map of normalized URL → array of tabs with that URL.
  * Only includes groups with 2+ tabs.
  */
-async function findDuplicateGroups(): Promise<Map<string, chrome.tabs.Tab[]>> {
-  const allTabs = await chrome.tabs.query({})
-  const groups = new Map<string, chrome.tabs.Tab[]>()
+async function findDuplicateGroups(): Promise<Map<string, browser.tabs.Tab[]>> {
+  const allTabs = await browser.tabs.query({})
+  const groups = new Map<string, browser.tabs.Tab[]>()
 
   for (const tab of allTabs) {
     if (!tab.url || !tab.id) continue
@@ -82,7 +83,7 @@ async function findDuplicateGroups(): Promise<Map<string, chrome.tabs.Tab[]>> {
   }
 
   // Filter to only groups with duplicates
-  const duplicates = new Map<string, chrome.tabs.Tab[]>()
+  const duplicates = new Map<string, browser.tabs.Tab[]>()
   for (const [url, tabs] of groups) {
     if (tabs.length >= 2) {
       duplicates.set(url, tabs)
@@ -143,13 +144,13 @@ export async function closeDuplicates(): Promise<DuplicateResult> {
   // Close tabs in batch, falling back to individual on error
   if (tabIdsToClose.length > 0) {
     try {
-      await chrome.tabs.remove(tabIdsToClose)
+      await browser.tabs.remove(tabIdsToClose)
       tabsClosed = tabIdsToClose.length
     } catch {
       // Batch failed, try individually
       for (const tabId of tabIdsToClose) {
         try {
-          await chrome.tabs.remove(tabId)
+          await browser.tabs.remove(tabId)
           tabsClosed++
         } catch {
           // Tab may have already been closed

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,10 +4,11 @@
  * MV3 service workers are terminated after ~30 seconds of inactivity.
  * This means:
  * - No persistent in-memory state
- * - Everything must be stored in chrome.storage
+ * - Everything must be stored in browser.storage
  * - Re-register alarms and listeners on every wake
  */
 
+import { browser } from '@/shared/browser'
 import { settingsStorage, tabActivityStorage, sessionsStorage, storage } from '@/shared/storage'
 import {
   ALARM_NAMES,
@@ -97,7 +98,7 @@ import { getDuplicateCount, closeDuplicates } from './deduplication'
 
 // Track previously active tab per window (for activity-on-leave tracking)
 // When user switches away from a tab, we touch it to record the departure time
-// NOTE: This is persisted to chrome.storage to survive service worker restarts
+// NOTE: This is persisted to browser.storage to survive service worker restarts
 let previousActiveTab: Map<number, number> = new Map() // windowId → tabId
 
 // Initialization promise - listeners wait on this before accessing state
@@ -149,7 +150,7 @@ async function savePreviousActiveTabs(): Promise<void> {
  * PWA, onStartup runs before any normal browser window exists. The regular
  * window gets restored later — AFTER onStartup has already finished. That
  * window's tabs never saw the initial discard pass, so `hibernateWindow()`
- * (called from chrome.windows.onCreated during the guard window) sweeps
+ * (called from browser.windows.onCreated during the guard window) sweeps
  * them up too.
  *
  * The 30s HIBERNATION_GUARD_DURATION_MS was tuned empirically against
@@ -157,26 +158,26 @@ async function savePreviousActiveTabs(): Promise<void> {
  * the PWA path — shorter windows regress #6.
  */
 async function maybeHibernateTab(tabId: number): Promise<void> {
-  const result = await chrome.storage.session.get(SESSION_KEYS.HIBERNATION_GUARD)
+  const result = await browser.storage.session.get(SESSION_KEYS.HIBERNATION_GUARD)
   const guard = result[SESSION_KEYS.HIBERNATION_GUARD] as
     | { expiresAt: number; tabIds: number[] }
     | undefined
   if (!guard) return
 
   if (Date.now() > guard.expiresAt) {
-    await chrome.storage.session.remove(SESSION_KEYS.HIBERNATION_GUARD)
+    await browser.storage.session.remove(SESSION_KEYS.HIBERNATION_GUARD)
     return
   }
 
   if (!guard.tabIds.includes(tabId)) return
 
-  const tab = await chrome.tabs.get(tabId)
+  const tab = await browser.tabs.get(tabId)
   if (tab.active) return
   if (tab.discarded) return
 
   console.log(`[Raft] Hibernation guard: discarding tab ${tabId} (${tab.url})`)
   try {
-    await chrome.tabs.discard(tabId)
+    await browser.tabs.discard(tabId)
   } catch (e) {
     console.warn(`[Raft] Hibernation guard: failed to discard tab ${tabId}:`, e)
   }
@@ -191,16 +192,16 @@ async function hibernateWindow(windowId: number): Promise<void> {
   const settings = await settingsStorage.get()
   if (!settings.suspension.hibernateOnStartup) return
 
-  const extensionOrigin = chrome.runtime.getURL('')
-  const winTabs = await chrome.tabs.query({ windowId })
+  const extensionOrigin = browser.runtime.getURL('')
+  const winTabs = await browser.tabs.query({ windowId })
 
   // Open a Raft page as the active tab so we can discard the user's active tab
   const raftTab = winTabs.find((t) => t.url?.startsWith(extensionOrigin))
   if (raftTab?.id) {
-    await chrome.tabs.update(raftTab.id, { active: true })
+    await browser.tabs.update(raftTab.id, { active: true })
   } else {
-    await chrome.tabs.create({
-      url: chrome.runtime.getURL('src/options/index.html#sessions'),
+    await browser.tabs.create({
+      url: browser.runtime.getURL('src/options/index.html#sessions'),
       active: true,
       windowId,
     })
@@ -298,7 +299,7 @@ export type { MessageResponse }
  * Only touches tabs that aren't already being tracked
  */
 async function initializeTabActivity(): Promise<void> {
-  const tabs = await chrome.tabs.query({})
+  const tabs = await browser.tabs.query({})
   const activity = await tabActivityStorage.getAll()
 
   let initialized = 0
@@ -330,7 +331,7 @@ async function initialize(): Promise<void> {
 
   // Populate initial active tabs per window (for activity-on-leave tracking)
   // This handles service worker restart after termination
-  const windows = await chrome.windows.getAll({ populate: true })
+  const windows = await browser.windows.getAll({ populate: true })
   let needsSave = false
   for (const window of windows) {
     if (window.id !== undefined && window.tabs) {
@@ -382,8 +383,8 @@ async function initialize(): Promise<void> {
  * Set up the suspension check alarm
  */
 async function setupSuspensionAlarm(): Promise<void> {
-  await chrome.alarms.clear(ALARM_NAMES.SUSPENSION_CHECK)
-  await chrome.alarms.create(ALARM_NAMES.SUSPENSION_CHECK, {
+  await browser.alarms.clear(ALARM_NAMES.SUSPENSION_CHECK)
+  await browser.alarms.create(ALARM_NAMES.SUSPENSION_CHECK, {
     periodInMinutes: SUSPENSION_CHECK_INTERVAL_MINUTES,
   })
 }
@@ -392,8 +393,8 @@ async function setupSuspensionAlarm(): Promise<void> {
  * Set up the auto-save alarm
  */
 async function setupAutoSaveAlarm(intervalMinutes: number): Promise<void> {
-  await chrome.alarms.clear(ALARM_NAMES.AUTO_SAVE)
-  await chrome.alarms.create(ALARM_NAMES.AUTO_SAVE, {
+  await browser.alarms.clear(ALARM_NAMES.AUTO_SAVE)
+  await browser.alarms.create(ALARM_NAMES.AUTO_SAVE, {
     periodInMinutes: intervalMinutes,
   })
 }
@@ -402,8 +403,8 @@ async function setupAutoSaveAlarm(intervalMinutes: number): Promise<void> {
  * Set up the cloud sync alarm
  */
 async function setupCloudSyncAlarm(intervalMinutes: number): Promise<void> {
-  await chrome.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
-  await chrome.alarms.create(ALARM_NAMES.CLOUD_SYNC, {
+  await browser.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
+  await browser.alarms.create(ALARM_NAMES.CLOUD_SYNC, {
     periodInMinutes: intervalMinutes,
   })
 }
@@ -412,8 +413,8 @@ async function setupCloudSyncAlarm(intervalMinutes: number): Promise<void> {
  * Set up the recovery snapshot alarm
  */
 async function setupRecoverySnapshotAlarm(): Promise<void> {
-  await chrome.alarms.clear(ALARM_NAMES.RECOVERY_SNAPSHOT)
-  await chrome.alarms.create(ALARM_NAMES.RECOVERY_SNAPSHOT, {
+  await browser.alarms.clear(ALARM_NAMES.RECOVERY_SNAPSHOT)
+  await browser.alarms.create(ALARM_NAMES.RECOVERY_SNAPSHOT, {
     periodInMinutes: RECOVERY_CONFIG.INTERVAL_MINUTES,
   })
 }
@@ -422,8 +423,8 @@ async function setupRecoverySnapshotAlarm(): Promise<void> {
  * Set up the export reminder alarm (runs daily to check if reminder is due)
  */
 async function setupExportReminderAlarm(): Promise<void> {
-  await chrome.alarms.clear(ALARM_NAMES.EXPORT_REMINDER)
-  await chrome.alarms.create(ALARM_NAMES.EXPORT_REMINDER, {
+  await browser.alarms.clear(ALARM_NAMES.EXPORT_REMINDER)
+  await browser.alarms.create(ALARM_NAMES.EXPORT_REMINDER, {
     periodInMinutes: 60 * 24, // Check once per day
     delayInMinutes: 60, // First check after 1 hour
   })
@@ -513,19 +514,19 @@ async function checkExportReminder(): Promise<void> {
  */
 async function setupContextMenus(): Promise<void> {
   // Remove existing menus first
-  await chrome.contextMenus.removeAll()
+  await browser.contextMenus.removeAll()
 
   // Add "Suspend this tab" menu item
   try {
-    chrome.contextMenus.create(
+    browser.contextMenus.create(
       {
         id: 'suspend-tab',
         title: 'Suspend this tab',
         contexts: ['page'],
       },
       () => {
-        if (chrome.runtime.lastError) {
-          console.warn('[Raft] Failed to create suspend-tab menu:', chrome.runtime.lastError)
+        if (browser.runtime.lastError) {
+          console.warn('[Raft] Failed to create suspend-tab menu:', browser.runtime.lastError)
         }
       }
     )
@@ -535,15 +536,18 @@ async function setupContextMenus(): Promise<void> {
 
   // Add "Suspend other tabs" menu item
   try {
-    chrome.contextMenus.create(
+    browser.contextMenus.create(
       {
         id: 'suspend-other-tabs',
         title: 'Suspend other tabs in window',
         contexts: ['page'],
       },
       () => {
-        if (chrome.runtime.lastError) {
-          console.warn('[Raft] Failed to create suspend-other-tabs menu:', chrome.runtime.lastError)
+        if (browser.runtime.lastError) {
+          console.warn(
+            '[Raft] Failed to create suspend-other-tabs menu:',
+            browser.runtime.lastError
+          )
         }
       }
     )
@@ -559,15 +563,15 @@ async function updateBadge(): Promise<void> {
   const settings = await settingsStorage.get()
 
   if (!settings.ui.showBadge) {
-    await chrome.action.setBadgeText({ text: '' })
+    await browser.action.setBadgeText({ text: '' })
     return
   }
 
   const counts = await getTabCounts()
   const text = counts.suspended > 0 ? counts.suspended.toString() : ''
 
-  await chrome.action.setBadgeText({ text })
-  await chrome.action.setBadgeBackgroundColor({ color: '#c07a42' }) // raft-500
+  await browser.action.setBadgeText({ text })
+  await browser.action.setBadgeBackgroundColor({ color: '#c07a42' }) // raft-500
 }
 
 // ============================================================================
@@ -577,14 +581,14 @@ async function updateBadge(): Promise<void> {
 /**
  * Handle alarm events
  */
-chrome.alarms.onAlarm.addListener(async (alarm) => {
+browser.alarms.onAlarm.addListener(async (alarm) => {
   switch (alarm.name) {
     case ALARM_NAMES.SUSPENSION_CHECK: {
       await checkForInactiveTabs()
       await updateBadge()
 
       // Periodically clean up orphaned tab activity records
-      const tabs = await chrome.tabs.query({})
+      const tabs = await browser.tabs.query({})
       const tabIds = new Set(tabs.map((t) => t.id).filter((id): id is number => id !== undefined))
       await tabActivityStorage.cleanup(tabIds)
       break
@@ -619,7 +623,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
  * Key insight: We track when the user LEAVES a tab, not when they arrive.
  * This ensures tabs aren't suspended until X minutes after departure.
  */
-chrome.tabs.onActivated.addListener(async (activeInfo) => {
+browser.tabs.onActivated.addListener(async (activeInfo) => {
   await initReady
 
   // Touch the PREVIOUS active tab (the one user just left)
@@ -638,7 +642,7 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 /**
  * Track tab updates (URL changes, discard state changes, etc.)
  */
-chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
+browser.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
   // Hibernation guard: discard tabs that loaded during startup window
   if (changeInfo.status === 'complete' || changeInfo.discarded === false) {
     await maybeHibernateTab(tabId)
@@ -665,7 +669,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
 /**
  * Clean up activity tracking when tabs are closed
  */
-chrome.tabs.onRemoved.addListener(async (tabId) => {
+browser.tabs.onRemoved.addListener(async (tabId) => {
   await tabActivityStorage.remove(tabId)
   await updateBadge()
 })
@@ -675,7 +679,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
  * window, hibernate its tabs. This handles the case where a PWA starts Chrome
  * first (triggering onStartup before the regular window exists).
  */
-chrome.windows.onCreated.addListener(async (win) => {
+browser.windows.onCreated.addListener(async (win) => {
   if (win.type !== 'normal' || !win.id) return
   await initReady
 
@@ -685,7 +689,7 @@ chrome.windows.onCreated.addListener(async (win) => {
   // Only hibernate the first normal window — this is effectively a "startup"
   // for the browser UI (e.g., PWA kept Chrome alive, user opens a browser window).
   // If other normal windows already exist, this is just a new window (Ctrl+N).
-  const normalWindows = await chrome.windows.getAll()
+  const normalWindows = await browser.windows.getAll()
   const normalCount = normalWindows.filter((w) => w.type === 'normal').length
   if (normalCount > 1) return
 
@@ -698,7 +702,7 @@ chrome.windows.onCreated.addListener(async (win) => {
 /**
  * Clean up previousActiveTab tracking when windows are closed
  */
-chrome.windows.onRemoved.addListener(async (windowId) => {
+browser.windows.onRemoved.addListener(async (windowId) => {
   await initReady
   previousActiveTab.delete(windowId)
   await savePreviousActiveTabs()
@@ -707,7 +711,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
 /**
  * Handle context menu clicks
  */
-chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+browser.contextMenus.onClicked.addListener(async (info, tab) => {
   if (!tab?.id) return
 
   switch (info.menuItemId) {
@@ -726,9 +730,9 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 /**
  * Handle messages from popup and other extension pages
  */
-chrome.runtime.onMessage.addListener((message: MessageType, sender, sendResponse) => {
+browser.runtime.onMessage.addListener((message: MessageType, sender, sendResponse) => {
   // Only accept messages from our own extension
-  if (sender.id !== chrome.runtime.id) {
+  if (sender.id !== browser.runtime.id) {
     sendResponse({ success: false, error: 'Unauthorized sender' })
     return true
   }
@@ -752,7 +756,7 @@ chrome.runtime.onMessage.addListener((message: MessageType, sender, sendResponse
 async function getTestWindowIds(): Promise<number[]> {
   const windowIds = await storage.get<number[]>(DEV_TEST_WINDOWS_KEY, [])
   // Filter out any windows that no longer exist
-  const existingWindows = await chrome.windows.getAll()
+  const existingWindows = await browser.windows.getAll()
   const existingIds = new Set(existingWindows.map((w) => w.id))
   const validIds = windowIds.filter((id) => existingIds.has(id))
   // Update storage if some windows were closed
@@ -783,7 +787,7 @@ async function createDevScenario(
 
   for (const windowSpec of scenario.windows) {
     // Create window with about:blank
-    const createdWindow = await chrome.windows.create({
+    const createdWindow = await browser.windows.create({
       url: 'about:blank',
       focused: windowSpec.focused ?? false,
     })
@@ -793,13 +797,13 @@ async function createDevScenario(
     await addTestWindowId(windowId)
 
     // Get the initial blank tab to remove later
-    const initialTabs = await chrome.tabs.query({ windowId })
+    const initialTabs = await browser.tabs.query({ windowId })
     const blankTabId = initialTabs[0]?.id
 
     // Create ungrouped tabs
     if (windowSpec.tabs) {
       for (const tabSpec of windowSpec.tabs) {
-        await chrome.tabs.create({
+        await browser.tabs.create({
           windowId,
           url: tabSpec.url,
           pinned: tabSpec.pinned ?? false,
@@ -816,7 +820,7 @@ async function createDevScenario(
 
         // Create tabs for this group
         for (const tabSpec of groupSpec.tabs) {
-          const tab = await chrome.tabs.create({
+          const tab = await browser.tabs.create({
             windowId,
             url: tabSpec.url,
             pinned: tabSpec.pinned ?? false,
@@ -832,15 +836,15 @@ async function createDevScenario(
         if (tabIds.length > 0) {
           // Cast to the required tuple type
           const tabIdsForGroup = tabIds as [number, ...number[]]
-          const groupId = await chrome.tabs.group({
+          const groupId = await browser.tabs.group({
             tabIds: tabIdsForGroup,
             createProperties: { windowId },
           })
 
           // Update group properties
-          await chrome.tabGroups.update(groupId, {
+          await browser.tabGroups.update(groupId, {
             title: groupSpec.title,
-            color: groupSpec.color as chrome.tabGroups.Color,
+            color: groupSpec.color as browser.tabGroups.Color,
             collapsed: groupSpec.collapsed ?? false,
           })
         }
@@ -850,7 +854,7 @@ async function createDevScenario(
     // Remove the initial blank tab
     if (blankTabId) {
       try {
-        await chrome.tabs.remove(blankTabId)
+        await browser.tabs.remove(blankTabId)
       } catch {
         // Tab may already be closed
       }
@@ -869,7 +873,7 @@ async function cleanupTestWindows(): Promise<{ closedCount: number }> {
 
   for (const windowId of windowIds) {
     try {
-      await chrome.windows.remove(windowId)
+      await browser.windows.remove(windowId)
       closedCount++
     } catch {
       // Window may already be closed
@@ -921,7 +925,7 @@ async function handleMessage(message: MessageType): Promise<MessageResponse> {
       }
 
       case 'GET_CURRENT_TAB_STATUS': {
-        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
+        const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
         if (!tab) {
           return { success: false, error: 'No active tab' }
         }
@@ -956,19 +960,19 @@ async function handleMessage(message: MessageType): Promise<MessageResponse> {
         if (settings.suspension.enabled) {
           await setupSuspensionAlarm()
         } else {
-          await chrome.alarms.clear(ALARM_NAMES.SUSPENSION_CHECK)
+          await browser.alarms.clear(ALARM_NAMES.SUSPENSION_CHECK)
         }
 
         if (settings.autoSave.enabled) {
           await setupAutoSaveAlarm(settings.autoSave.intervalMinutes)
         } else {
-          await chrome.alarms.clear(ALARM_NAMES.AUTO_SAVE)
+          await browser.alarms.clear(ALARM_NAMES.AUTO_SAVE)
         }
 
         if (settings.exportReminder.enabled) {
           await setupExportReminderAlarm()
         } else {
-          await chrome.alarms.clear(ALARM_NAMES.EXPORT_REMINDER)
+          await browser.alarms.clear(ALARM_NAMES.EXPORT_REMINDER)
         }
 
         await updateBadge()
@@ -1301,7 +1305,7 @@ async function handleMessage(message: MessageType): Promise<MessageResponse> {
         await clearAllCloudSyncData()
 
         // Cancel sync alarm
-        await chrome.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
+        await browser.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
 
         return { success: true }
       }
@@ -1376,14 +1380,14 @@ async function handleMessage(message: MessageType): Promise<MessageResponse> {
         if (settings.enabled) {
           await setupCloudSyncAlarm(settings.intervalMinutes)
         } else {
-          await chrome.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
+          await browser.alarms.clear(ALARM_NAMES.CLOUD_SYNC)
         }
 
         return { success: true, data: settings }
       }
 
       case 'CLOUD_GET_SYNCED_IDS': {
-        const result = await chrome.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
+        const result = await browser.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
         const ids = (result[CLOUD_SYNC_KEYS.SYNCED_IDS] as string[] | undefined) ?? []
         return { success: true, data: ids }
       }
@@ -1596,7 +1600,7 @@ async function handleMessage(message: MessageType): Promise<MessageResponse> {
 /**
  * Handle extension install/update
  */
-chrome.runtime.onInstalled.addListener(async (details) => {
+browser.runtime.onInstalled.addListener(async (details) => {
   console.log('[Raft] Extension installed/updated:', details.reason)
 
   if (details.reason === 'install') {
@@ -1629,8 +1633,8 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     }
 
     // Open onboarding page for new users
-    const onboardingUrl = chrome.runtime.getURL('src/onboarding/index.html')
-    chrome.tabs.create({ url: onboardingUrl })
+    const onboardingUrl = browser.runtime.getURL('src/onboarding/index.html')
+    browser.tabs.create({ url: onboardingUrl })
   } else if (details.reason === 'update') {
     console.log('[Raft] Updated from version:', details.previousVersion)
 
@@ -1660,27 +1664,27 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 /**
  * Handle service worker startup (wake from termination)
  */
-chrome.runtime.onStartup.addListener(async () => {
+browser.runtime.onStartup.addListener(async () => {
   // Don't call initialize() here - it runs at the bottom of the script
   await initReady
   const settings = await settingsStorage.get()
   if (settings.suspension.hibernateOnStartup) {
     console.log('[Raft] Hibernate on startup enabled, suspending all tabs')
-    const allWindows = await chrome.windows.getAll()
+    const allWindows = await browser.windows.getAll()
     const windows = allWindows.filter((w) => w.type === 'normal')
-    const extensionOrigin = chrome.runtime.getURL('')
+    const extensionOrigin = browser.runtime.getURL('')
     const hibernateTabIds: number[] = []
     for (const win of windows) {
       if (!win.id) continue
-      // We need a Raft extension page as the active tab so chrome.tabs.discard()
+      // We need a Raft extension page as the active tab so browser.tabs.discard()
       // can suspend the user's previously-active tab. Reuse one if already open.
-      const winTabs = await chrome.tabs.query({ windowId: win.id })
+      const winTabs = await browser.tabs.query({ windowId: win.id })
       const raftTab = winTabs.find((t) => t.url?.startsWith(extensionOrigin))
       if (raftTab?.id) {
-        await chrome.tabs.update(raftTab.id, { active: true })
+        await browser.tabs.update(raftTab.id, { active: true })
       } else {
-        await chrome.tabs.create({
-          url: chrome.runtime.getURL('src/options/index.html#sessions'),
+        await browser.tabs.create({
+          url: browser.runtime.getURL('src/options/index.html#sessions'),
           active: true,
           windowId: win.id,
         })
@@ -1703,7 +1707,7 @@ chrome.runtime.onStartup.addListener(async () => {
     // Guard catches tabs that couldn't be discarded yet (no main frame),
     // tabs Chrome's startup loader undiscards, and normal windows that
     // appear after onStartup (e.g., PWA started Chrome first)
-    await chrome.storage.session.set({
+    await browser.storage.session.set({
       [SESSION_KEYS.HIBERNATION_GUARD]: {
         expiresAt: Date.now() + HIBERNATION_GUARD_DURATION_MS,
         tabIds: hibernateTabIds,
@@ -1716,10 +1720,10 @@ chrome.runtime.onStartup.addListener(async () => {
 })
 
 // Handle keyboard commands
-chrome.commands.onCommand.addListener(async (command) => {
+browser.commands.onCommand.addListener(async (command) => {
   switch (command) {
     case 'suspend-current-tab': {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
+      const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
       if (tab?.id) {
         await suspendTab(tab.id)
         await updateBadge()
@@ -1728,7 +1732,7 @@ chrome.commands.onCommand.addListener(async (command) => {
     }
 
     case 'suspend-other-tabs': {
-      const window = await chrome.windows.getCurrent()
+      const window = await browser.windows.getCurrent()
       await suspendOtherTabs(window.id)
       await updateBadge()
       break

--- a/src/background/recovery.ts
+++ b/src/background/recovery.ts
@@ -29,6 +29,7 @@ import {
 import type { RecoverySnapshot, Window, Tab, TabGroup } from '@/shared/types'
 import { nanoid } from 'nanoid'
 import { compressToUTF16, decompressFromUTF16 } from 'lz-string'
+import { browser } from '@/shared/browser'
 
 /**
  * Check if a URL is protected (should not be included in snapshots)
@@ -259,7 +260,7 @@ export const recoverySnapshotSync = {
         tabCount: snapshot.stats.tabCount,
       }
 
-      await chrome.storage.sync.set(updates)
+      await browser.storage.sync.set(updates)
       return true
     } catch (error) {
       console.error('[Raft] Failed to sync recovery snapshot:', error)
@@ -273,7 +274,7 @@ export const recoverySnapshotSync = {
   async get(): Promise<RecoverySnapshot | null> {
     try {
       // First check for chunked format
-      const metaResult = await chrome.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
+      const metaResult = await browser.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
       const meta = metaResult[SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY] as
         | { chunkCount: number }
         | undefined
@@ -284,7 +285,7 @@ export const recoverySnapshotSync = {
           { length: meta.chunkCount },
           (_, i) => `${SYNC_CHUNK_CONFIG.CHUNK_PREFIX}${i}`
         )
-        const chunksResult = await chrome.storage.sync.get(chunkKeys)
+        const chunksResult = await browser.storage.sync.get(chunkKeys)
 
         // Reassemble the compressed string
         let lzCompressed = ''
@@ -309,7 +310,7 @@ export const recoverySnapshotSync = {
       }
 
       // Fall back to legacy single-item format for backwards compatibility
-      const result = await chrome.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
+      const result = await browser.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
       const stored = result[SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT]
 
       if (!stored) {
@@ -346,7 +347,7 @@ export const recoverySnapshotSync = {
   async getSize(): Promise<number> {
     try {
       // Check for chunked format first
-      const metaResult = await chrome.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
+      const metaResult = await browser.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
       const meta = metaResult[SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY] as
         | { chunkCount: number }
         | undefined
@@ -356,7 +357,7 @@ export const recoverySnapshotSync = {
           { length: meta.chunkCount },
           (_, i) => `${SYNC_CHUNK_CONFIG.CHUNK_PREFIX}${i}`
         )
-        const chunksResult = await chrome.storage.sync.get(chunkKeys)
+        const chunksResult = await browser.storage.sync.get(chunkKeys)
 
         const encoder = new TextEncoder()
         let totalSize = 0
@@ -372,7 +373,7 @@ export const recoverySnapshotSync = {
       }
 
       // Fall back to legacy single-item format
-      const result = await chrome.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
+      const result = await browser.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
       const stored = result[SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT]
       if (!stored) return 0
       if (typeof stored === 'string') {
@@ -389,7 +390,7 @@ export const recoverySnapshotSync = {
    */
   async getMetadata(): Promise<{ timestamp: number; tabCount: number; chunkCount: number } | null> {
     try {
-      const metaResult = await chrome.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
+      const metaResult = await browser.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
       const meta = metaResult[SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY] as
         | { chunkCount: number; timestamp: number; tabCount: number }
         | undefined
@@ -399,7 +400,7 @@ export const recoverySnapshotSync = {
       }
 
       // Fall back to legacy format - need to load and parse
-      const result = await chrome.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
+      const result = await browser.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
       const stored = result[SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT]
 
       if (!stored) return null
@@ -444,7 +445,7 @@ export const recoverySnapshotSync = {
         keysToRemove.push(`${SYNC_CHUNK_CONFIG.CHUNK_PREFIX}${i}`)
       }
 
-      await chrome.storage.sync.remove(keysToRemove)
+      await browser.storage.sync.remove(keysToRemove)
     } catch (error) {
       console.error('[Raft] Failed to clear recovery snapshot from sync:', error)
     }
@@ -457,7 +458,7 @@ export const recoverySnapshotSync = {
  */
 export async function captureRecoverySnapshot(): Promise<RecoverySnapshot | null> {
   try {
-    const chromeWindows = await chrome.windows.getAll({ populate: true })
+    const chromeWindows = await browser.windows.getAll({ populate: true })
     const now = Date.now()
 
     const windows: Window[] = []
@@ -468,7 +469,7 @@ export async function captureRecoverySnapshot(): Promise<RecoverySnapshot | null
       if (!win.id || win.type !== 'normal') continue
 
       // Get tab groups for this window
-      const chromeGroups = await chrome.tabGroups.query({ windowId: win.id })
+      const chromeGroups = await browser.tabGroups.query({ windowId: win.id })
       const groupIdMap = new Map<number, string>()
 
       const tabGroups: TabGroup[] = chromeGroups.map((group) => {
@@ -477,7 +478,7 @@ export async function captureRecoverySnapshot(): Promise<RecoverySnapshot | null
         return {
           id,
           title: group.title || '',
-          color: group.color as chrome.tabGroups.Color,
+          color: group.color as browser.tabGroups.Color,
           collapsed: group.collapsed,
         }
       })
@@ -515,7 +516,7 @@ export async function captureRecoverySnapshot(): Promise<RecoverySnapshot | null
         tabs,
         tabGroups,
         focused: win.focused,
-        state: win.state as chrome.windows.WindowState,
+        state: win.state as browser.windows.WindowState,
       })
     }
 
@@ -617,7 +618,7 @@ export async function restoreFromSnapshot(
       if (urls.length === 0) continue
 
       // Create window with all tabs
-      const createdWindow = await chrome.windows.create({
+      const createdWindow = await browser.windows.create({
         url: urls,
         focused: window.focused,
         state: window.state,
@@ -627,7 +628,7 @@ export async function restoreFromSnapshot(
       windowsCreated++
 
       // Get the created tabs to set up groups and pinned state
-      const createdTabs = await chrome.tabs.query({ windowId: createdWindow.id })
+      const createdTabs = await browser.tabs.query({ windowId: createdWindow.id })
       tabsCreated += createdTabs.length
 
       // Map our group IDs to Chrome group IDs
@@ -650,14 +651,14 @@ export async function restoreFromSnapshot(
 
         if (groupTabIds.length > 0) {
           try {
-            const chromeGroupId = await chrome.tabs.group({
+            const chromeGroupId = await browser.tabs.group({
               tabIds: groupTabIds as [number, ...number[]],
               createProperties: { windowId: createdWindow.id },
             })
             groupIdMap.set(group.id, chromeGroupId)
 
             // Update group properties
-            await chrome.tabGroups.update(chromeGroupId, {
+            await browser.tabGroups.update(chromeGroupId, {
               title: group.title,
               color: group.color,
               collapsed: group.collapsed,
@@ -674,7 +675,7 @@ export async function restoreFromSnapshot(
           const createdTab = createdTabs.find((ct) => ct.index === tab.index)
           if (createdTab?.id) {
             try {
-              await chrome.tabs.update(createdTab.id, { pinned: true })
+              await browser.tabs.update(createdTab.id, { pinned: true })
             } catch (err) {
               console.warn('[Raft] Failed to pin tab:', err)
             }

--- a/src/background/sessions.ts
+++ b/src/background/sessions.ts
@@ -21,6 +21,7 @@ import type {
 } from '@/shared/types'
 import { backupSession, removeSessionFromSync } from '@/shared/syncBackup'
 import { syncEngine, cloudSyncSettingsStorage } from '@/shared/cloudSync'
+import { browser } from '@/shared/browser'
 
 /** Cached search index: session ID → pre-lowercased searchable string */
 let searchIndex: Map<string, string> | null = null
@@ -64,7 +65,7 @@ export async function captureCurrentSession(
   name?: string,
   source: SessionSource = 'manual'
 ): Promise<Session> {
-  const windows = await chrome.windows.getAll({ populate: true })
+  const windows = await browser.windows.getAll({ populate: true })
   const now = Date.now()
 
   const sessionWindows: Window[] = []
@@ -73,7 +74,7 @@ export async function captureCurrentSession(
     if (!win.id || win.type !== 'normal') continue
 
     // Get tab groups for this window
-    const chromeGroups = await chrome.tabGroups.query({ windowId: win.id })
+    const chromeGroups = await browser.tabGroups.query({ windowId: win.id })
     const groupIdMap = new Map<number, string>()
 
     const tabGroups: TabGroup[] = chromeGroups.map((group) => {
@@ -115,7 +116,7 @@ export async function captureCurrentSession(
       tabs,
       tabGroups,
       focused: win.focused,
-      state: win.state as chrome.windows.WindowState,
+      state: win.state as browser.windows.WindowState,
     })
   }
 
@@ -135,11 +136,11 @@ export async function captureCurrentSession(
  * Capture a single window
  */
 export async function captureWindow(windowId: number, name?: string): Promise<Session> {
-  const win = await chrome.windows.get(windowId, { populate: true })
+  const win = await browser.windows.get(windowId, { populate: true })
   const now = Date.now()
 
   // Get tab groups for this window
-  const chromeGroups = await chrome.tabGroups.query({ windowId })
+  const chromeGroups = await browser.tabGroups.query({ windowId })
   const groupIdMap = new Map<number, string>()
 
   const tabGroups: TabGroup[] = chromeGroups.map((group) => {
@@ -184,7 +185,7 @@ export async function captureWindow(windowId: number, name?: string): Promise<Se
         tabs,
         tabGroups,
         focused: win.focused,
-        state: win.state as chrome.windows.WindowState,
+        state: win.state as browser.windows.WindowState,
       },
     ],
     source: 'manual',
@@ -205,7 +206,7 @@ async function waitForTabNavigation(
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     try {
-      const tab = await chrome.tabs.get(tabId)
+      const tab = await browser.tabs.get(tabId)
       if (tab.url && tab.url !== 'about:blank') return true
     } catch {
       return false // Tab closed
@@ -251,9 +252,9 @@ async function restoreWindows(
       const firstTab = sessionWindow.tabs[0]
       if (!firstTab) continue
 
-      let newWindow: chrome.windows.Window | undefined
+      let newWindow: browser.windows.Window | undefined
       try {
-        newWindow = await chrome.windows.create({
+        newWindow = await browser.windows.create({
           url: firstTab.url,
           focused: sessionWindow.focused,
           state: sessionWindow.state,
@@ -291,7 +292,7 @@ async function restoreWindows(
         const tab = sessionWindow.tabs[i]
 
         try {
-          const newTab = await chrome.tabs.create({
+          const newTab = await browser.tabs.create({
             windowId: newWindowId,
             url: tab.url,
             index: tab.index,
@@ -312,20 +313,20 @@ async function restoreWindows(
               try {
                 const existingGroupId = groupIdMap.get(tab.groupId)
                 if (existingGroupId !== undefined) {
-                  await chrome.tabs.group({
+                  await browser.tabs.group({
                     tabIds: newTab.id,
                     groupId: existingGroupId,
                   })
                 } else {
                   const sessionGroup = sessionWindow.tabGroups.find((g) => g.id === tab.groupId)
                   if (sessionGroup) {
-                    const newGroupId = await chrome.tabs.group({
+                    const newGroupId = await browser.tabs.group({
                       tabIds: newTab.id,
                       createProperties: { windowId: newWindowId },
                     })
                     groupIdMap.set(tab.groupId, newGroupId)
 
-                    await chrome.tabGroups.update(newGroupId, {
+                    await browser.tabGroups.update(newGroupId, {
                       title: sessionGroup.title,
                       color: sessionGroup.color,
                       collapsed: sessionGroup.collapsed,
@@ -347,20 +348,20 @@ async function restoreWindows(
         try {
           const existingGroupId = groupIdMap.get(firstTab.groupId)
           if (existingGroupId !== undefined) {
-            await chrome.tabs.group({
+            await browser.tabs.group({
               tabIds: firstTabId,
               groupId: existingGroupId,
             })
           } else {
             const sessionGroup = sessionWindow.tabGroups.find((g) => g.id === firstTab.groupId)
             if (sessionGroup) {
-              const newGroupId = await chrome.tabs.group({
+              const newGroupId = await browser.tabs.group({
                 tabIds: firstTabId,
                 createProperties: { windowId: newWindowId },
               })
               groupIdMap.set(firstTab.groupId, newGroupId)
 
-              await chrome.tabGroups.update(newGroupId, {
+              await browser.tabGroups.update(newGroupId, {
                 title: sessionGroup.title,
                 color: sessionGroup.color,
                 collapsed: sessionGroup.collapsed,
@@ -375,7 +376,7 @@ async function restoreWindows(
       // Pin the first tab if needed (must be done after grouping)
       if (firstTabId && firstTab.pinned) {
         try {
-          await chrome.tabs.update(firstTabId, { pinned: true })
+          await browser.tabs.update(firstTabId, { pinned: true })
         } catch (err) {
           console.warn(`[Raft] Failed to pin first tab "${firstTab.title}":`, err)
         }
@@ -398,7 +399,7 @@ async function restoreWindows(
           console.warn(`[Raft] Tab ${tabId} navigation did not commit, skipping discard`)
           return
         }
-        await chrome.tabs.discard(tabId)
+        await browser.tabs.discard(tabId)
       })
     )
     for (const r of results) {

--- a/src/background/suspension.ts
+++ b/src/background/suspension.ts
@@ -12,6 +12,7 @@
 import { settingsStorage, tabActivityStorage } from '@/shared/storage'
 import { PROTECTED_URL_PATTERNS } from '@/shared/constants'
 import type { Settings } from '@/shared/types'
+import { browser } from '@/shared/browser'
 
 /**
  * Result of checking if a tab can be suspended
@@ -64,7 +65,7 @@ function matchesWhitelist(url: string, whitelist: string[]): boolean {
  * Check if a tab can be suspended based on protection rules
  */
 export async function canSuspendTab(
-  tab: chrome.tabs.Tab,
+  tab: browser.tabs.Tab,
   settings?: Settings
 ): Promise<SuspensionCheck> {
   const s = settings ?? (await settingsStorage.get())
@@ -108,7 +109,7 @@ export async function canSuspendTab(
  */
 export async function suspendTab(tabId: number): Promise<boolean> {
   try {
-    const tab = await chrome.tabs.get(tabId)
+    const tab = await browser.tabs.get(tabId)
     const check = await canSuspendTab(tab)
 
     if (!check.canSuspend) {
@@ -116,7 +117,7 @@ export async function suspendTab(tabId: number): Promise<boolean> {
     }
 
     // Use native discard API
-    const discardedTab = await chrome.tabs.discard(tabId)
+    const discardedTab = await browser.tabs.discard(tabId)
 
     if (discardedTab?.discarded) {
       return true
@@ -132,8 +133,8 @@ export async function suspendTab(tabId: number): Promise<boolean> {
  * Suspend all other tabs in the current window
  */
 export async function suspendOtherTabs(windowId?: number): Promise<number> {
-  const targetWindowId = windowId ?? (await chrome.windows.getCurrent()).id
-  const tabs = await chrome.tabs.query({ windowId: targetWindowId })
+  const targetWindowId = windowId ?? (await browser.windows.getCurrent()).id
+  const tabs = await browser.tabs.query({ windowId: targetWindowId })
   const settings = await settingsStorage.get()
 
   let suspended = 0
@@ -152,12 +153,12 @@ export async function suspendOtherTabs(windowId?: number): Promise<number> {
 
 /**
  * Suspend all non-active tabs across all windows.
- * Active tabs are skipped because chrome.tabs.discard() cannot discard the active tab.
+ * Active tabs are skipped because browser.tabs.discard() cannot discard the active tab.
  * For startup hibernation (which needs to suspend active tabs too), the onStartup
  * handler opens a Raft page as the active tab first, then uses suspendOtherTabs().
  */
 export async function suspendAllTabs(): Promise<number> {
-  const windows = await chrome.windows.getAll({ populate: true })
+  const windows = await browser.windows.getAll({ populate: true })
   const settings = await settingsStorage.get()
   let suspended = 0
 
@@ -193,7 +194,7 @@ export async function checkForInactiveTabs(): Promise<number> {
   const cutoff = now - inactivityMs
 
   const activity = await tabActivityStorage.getAll()
-  const tabs = await chrome.tabs.query({})
+  const tabs = await browser.tabs.query({})
 
   let suspended = 0
   for (const tab of tabs) {
@@ -226,9 +227,9 @@ export async function checkForInactiveTabs(): Promise<number> {
  */
 export async function getWindowTabsStatus(
   windowId?: number
-): Promise<Array<{ tab: chrome.tabs.Tab; canSuspend: boolean; reason?: string }>> {
-  const targetWindowId = windowId ?? (await chrome.windows.getCurrent()).id
-  const tabs = await chrome.tabs.query({ windowId: targetWindowId })
+): Promise<Array<{ tab: browser.tabs.Tab; canSuspend: boolean; reason?: string }>> {
+  const targetWindowId = windowId ?? (await browser.windows.getCurrent()).id
+  const tabs = await browser.tabs.query({ windowId: targetWindowId })
   const settings = await settingsStorage.get()
 
   const results = []
@@ -252,7 +253,7 @@ export async function getTabCounts(): Promise<{
   suspended: number
   suspendable: number
 }> {
-  const tabs = await chrome.tabs.query({})
+  const tabs = await browser.tabs.query({})
   const settings = await settingsStorage.get()
 
   let suspended = 0
@@ -280,14 +281,14 @@ export async function getTabCounts(): Promise<{
  * Restore all suspended tabs in a window by reloading them
  */
 export async function restoreAllTabs(windowId?: number): Promise<number> {
-  const targetWindowId = windowId ?? (await chrome.windows.getCurrent()).id
-  const tabs = await chrome.tabs.query({ windowId: targetWindowId, discarded: true })
+  const targetWindowId = windowId ?? (await browser.windows.getCurrent()).id
+  const tabs = await browser.tabs.query({ windowId: targetWindowId, discarded: true })
 
   let restored = 0
   for (const tab of tabs) {
     if (tab.id) {
       try {
-        await chrome.tabs.reload(tab.id)
+        await browser.tabs.reload(tab.id)
         restored++
       } catch (error) {
         console.warn(`[Raft] Failed to reload tab ${tab.id}:`, error)

--- a/src/onboarding/index.tsx
+++ b/src/onboarding/index.tsx
@@ -9,6 +9,7 @@ import { render } from 'preact'
 import { Otter } from '@/shared/components/Otter'
 import { SkipLink } from '@/shared/a11y'
 import './styles.css'
+import { browser } from '@/shared/browser'
 
 function FeatureItem({
   icon,
@@ -38,10 +39,10 @@ function FeatureItem({
 function App() {
   const handleGetStarted = () => {
     // Mark onboarding as complete
-    chrome.storage.local.set({ onboardingComplete: true })
+    browser.storage.local.set({ onboardingComplete: true })
     // Navigate to options page instead of closing immediately
     // This allows users to reference onboarding info and configure settings
-    chrome.runtime.openOptionsPage()
+    browser.runtime.openOptionsPage()
   }
 
   return (

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/shared/utils'
 import { SkipLink, LiveRegion } from '@/shared/a11y'
 import { useAnnounce, useFocusTrap, useFocusRestore } from '@/shared/a11y'
+import { browser } from '@/shared/browser'
 
 type TabType = 'general' | 'sessions' | 'browser-sync' | 'cloud' | 'about' | 'dev'
 
@@ -117,13 +118,13 @@ export function App() {
   const debouncedSaveSettings = useRef(
     debounce(async (updated: Settings) => {
       await settingsStorage.save(updated)
-      await chrome.runtime.sendMessage({ type: 'UPDATE_SETTINGS', settings: updated })
+      await browser.runtime.sendMessage({ type: 'UPDATE_SETTINGS', settings: updated })
       success('Settings saved')
     }, 500)
   ).current
 
   const loadSyncStatus = useCallback(() => {
-    chrome.runtime
+    browser.runtime
       .sendMessage({ type: 'GET_SYNC_STATUS' })
       .then((response) => {
         if (response.success) {
@@ -138,8 +139,8 @@ export function App() {
 
   const loadCloudSyncedIds = useCallback(() => {
     Promise.all([
-      chrome.runtime.sendMessage({ type: 'CLOUD_GET_SYNCED_IDS' }),
-      chrome.runtime.sendMessage({ type: 'CLOUD_GET_STATUS' }),
+      browser.runtime.sendMessage({ type: 'CLOUD_GET_SYNCED_IDS' }),
+      browser.runtime.sendMessage({ type: 'CLOUD_GET_STATUS' }),
     ])
       .then(([idsResponse, statusResponse]) => {
         if (idsResponse.success) {
@@ -155,7 +156,7 @@ export function App() {
   }, [])
 
   const loadRecoverySnapshots = useCallback(() => {
-    chrome.runtime
+    browser.runtime
       .sendMessage({ type: 'GET_RECOVERY_SNAPSHOTS' })
       .then((response) => {
         if (response.success) {
@@ -168,7 +169,7 @@ export function App() {
   }, [])
 
   const loadExportReminderState = useCallback(() => {
-    chrome.runtime
+    browser.runtime
       .sendMessage({ type: 'GET_EXPORT_REMINDER_STATE' })
       .then((response) => {
         if (response.success) {
@@ -181,7 +182,7 @@ export function App() {
   }, [])
 
   const dismissExportReminder = useCallback(() => {
-    chrome.runtime
+    browser.runtime
       .sendMessage({ type: 'DISMISS_EXPORT_REMINDER' })
       .then(() => {
         setExportReminderState(null)
@@ -193,7 +194,7 @@ export function App() {
   }, [success, showError])
 
   const markExportComplete = useCallback(() => {
-    chrome.runtime
+    browser.runtime
       .sendMessage({ type: 'MARK_EXPORT_COMPLETE' })
       .then(() => {
         setExportReminderState(null)
@@ -220,7 +221,9 @@ export function App() {
     checkProStatus()
 
     // Listen for storage changes to refresh data in real-time
-    const handleLocalStorageChange = (changes: { [key: string]: chrome.storage.StorageChange }) => {
+    const handleLocalStorageChange = (changes: {
+      [key: string]: browser.storage.StorageChange
+    }) => {
       if (changes[STORAGE_KEYS.SESSIONS]) {
         loadSessions()
       }
@@ -243,11 +246,11 @@ export function App() {
       loadSyncStatus()
     }
 
-    chrome.storage.local.onChanged.addListener(handleLocalStorageChange)
-    chrome.storage.sync.onChanged.addListener(handleSyncStorageChange)
+    browser.storage.local.onChanged.addListener(handleLocalStorageChange)
+    browser.storage.sync.onChanged.addListener(handleSyncStorageChange)
     return () => {
-      chrome.storage.local.onChanged.removeListener(handleLocalStorageChange)
-      chrome.storage.sync.onChanged.removeListener(handleSyncStorageChange)
+      browser.storage.local.onChanged.removeListener(handleLocalStorageChange)
+      browser.storage.sync.onChanged.removeListener(handleSyncStorageChange)
     }
   }, [
     loadSessions,
@@ -258,7 +261,7 @@ export function App() {
   ])
 
   const checkProStatus = () => {
-    chrome.runtime
+    browser.runtime
       .sendMessage({ type: 'PRO_CHECK_STATUS' })
       .then((response) => {
         if (response.success) {
@@ -390,7 +393,7 @@ export function App() {
   const handleRestoreRecoverySnapshot = async (snapshotId: string) => {
     setRecoveryLoading(true)
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'RESTORE_RECOVERY_SNAPSHOT',
         snapshotId,
       })
@@ -410,7 +413,7 @@ export function App() {
 
   const handleDeleteRecoverySnapshot = async (snapshotId: string) => {
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'DELETE_RECOVERY_SNAPSHOT',
         snapshotId,
       })
@@ -1227,7 +1230,7 @@ export function App() {
                         <button
                           onClick={() => {
                             setRestoringSync(true)
-                            chrome.runtime
+                            browser.runtime
                               .sendMessage({ type: 'RESTORE_FROM_SYNC' })
                               .then((response) => {
                                 if (response.success) {
@@ -1259,7 +1262,7 @@ export function App() {
                               return
                             }
                             setClearingSync(true)
-                            chrome.runtime
+                            browser.runtime
                               .sendMessage({ type: 'CLEAR_SYNC_DATA' })
                               .then((response) => {
                                 if (response.success) {

--- a/src/options/components/BackupDashboard.tsx
+++ b/src/options/components/BackupDashboard.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback } from 'preact/hooks'
 import type { BackupHealthData, BackupLayerStatus, HealthLevel } from '@/shared/backupHealth'
 import { formatRelativeTime } from '@/shared/utils'
+import { browser } from '@/shared/browser'
 
 const LEVEL_STYLES: Record<
   HealthLevel,
@@ -52,7 +53,7 @@ export function BackupDashboard({ isPro, onNavigateTab }: BackupDashboardProps) 
 
   const loadHealth = useCallback(async () => {
     try {
-      const response = await chrome.runtime.sendMessage({ type: 'GET_BACKUP_HEALTH' })
+      const response = await browser.runtime.sendMessage({ type: 'GET_BACKUP_HEALTH' })
       if (response.success) {
         setHealth(response.data)
       }

--- a/src/options/components/CloudSyncPanel.tsx
+++ b/src/options/components/CloudSyncPanel.tsx
@@ -12,6 +12,7 @@ import { formatRelativeTime } from '@/shared/utils'
 import { EncryptionSetup } from './EncryptionSetup'
 import { ProUpgrade } from './ProUpgrade'
 import { useFocusTrap, useFocusRestore } from '@/shared/a11y'
+import { browser } from '@/shared/browser'
 
 interface CloudSyncStatus extends SyncState {
   configured: boolean
@@ -94,8 +95,8 @@ export function CloudSyncPanel({
   const loadStatus = useCallback(async () => {
     try {
       const [statusResponse, settingsResponse] = await Promise.all([
-        chrome.runtime.sendMessage({ type: 'CLOUD_GET_STATUS' }),
-        chrome.runtime.sendMessage({ type: 'CLOUD_GET_SETTINGS' }),
+        browser.runtime.sendMessage({ type: 'CLOUD_GET_STATUS' }),
+        browser.runtime.sendMessage({ type: 'CLOUD_GET_SETTINGS' }),
       ])
 
       if (statusResponse.success) {
@@ -123,7 +124,7 @@ export function CloudSyncPanel({
 
     setConnecting(true)
     try {
-      const response = await chrome.runtime.sendMessage({ type: 'CLOUD_CONNECT' })
+      const response = await browser.runtime.sendMessage({ type: 'CLOUD_CONNECT' })
 
       if (!response.success) {
         onError(response.error || 'Failed to connect')
@@ -183,7 +184,7 @@ export function CloudSyncPanel({
     setRegenError('')
     setRegenLoading(true)
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'CLOUD_REGENERATE_RECOVERY_KEY',
         password: regenPassword,
       })
@@ -233,7 +234,7 @@ export function CloudSyncPanel({
     setRecoveryError('')
     setRecoveryLoading(true)
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'CLOUD_RECOVER_WITH_KEY',
         recoveryKey: recoveryKeyInput.trim(),
         newPassword: recoveryNewPassword,
@@ -279,7 +280,7 @@ export function CloudSyncPanel({
     setUnlockError('')
     setUnlocking(true)
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'CLOUD_UNLOCK',
         password: unlockPassword,
         tokens: pendingTokens?.tokens,
@@ -320,7 +321,7 @@ export function CloudSyncPanel({
     restoreDisconnectFocus()
     setDisconnecting(true)
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'CLOUD_DISCONNECT',
         deleteCloudData,
       })
@@ -342,7 +343,7 @@ export function CloudSyncPanel({
   const handleSync = async () => {
     setSyncing(true)
     try {
-      const response = await chrome.runtime.sendMessage({ type: 'CLOUD_SYNC' })
+      const response = await browser.runtime.sendMessage({ type: 'CLOUD_SYNC' })
       if (response.success) {
         const result = response.data
         onSuccess(
@@ -362,7 +363,7 @@ export function CloudSyncPanel({
   const handleReconnect = async () => {
     setReconnecting(true)
     try {
-      const response = await chrome.runtime.sendMessage({ type: 'CLOUD_RECONNECT' })
+      const response = await browser.runtime.sendMessage({ type: 'CLOUD_RECONNECT' })
       if (response.success) {
         onSuccess('Reconnected to Google Drive')
         loadStatus()
@@ -380,14 +381,14 @@ export function CloudSyncPanel({
     if (!confirm('Are you sure you want to remove your license from this device?')) {
       return
     }
-    await chrome.runtime.sendMessage({ type: 'PRO_CLEAR_LICENSE' })
+    await browser.runtime.sendMessage({ type: 'PRO_CLEAR_LICENSE' })
     onProStatusChange()
   }
 
   const handleSettingChange = async (updates: Partial<CloudSyncSettings>) => {
     const updated = { ...settings, ...updates }
     setSettings(updated)
-    await chrome.runtime.sendMessage({ type: 'CLOUD_UPDATE_SETTINGS', settings: updates })
+    await browser.runtime.sendMessage({ type: 'CLOUD_UPDATE_SETTINGS', settings: updates })
   }
 
   if (loading) {

--- a/src/options/components/DevToolsPanel.tsx
+++ b/src/options/components/DevToolsPanel.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'preact/hooks'
 import { allScenarios } from '@/devtools/scenarios'
 import type { DevScenario } from '@/devtools/types'
 import { DEV_PRO_OVERRIDE_KEY } from '@/shared/constants'
+import { browser } from '@/shared/browser'
 
 interface DevToolsPanelProps {
   onSuccess: (message: string) => void
@@ -23,7 +24,7 @@ export function DevToolsPanel({ onSuccess, onError }: DevToolsPanelProps) {
   // Load test window count on mount and after changes
   const loadTestWindowCount = async () => {
     try {
-      const response = await chrome.runtime.sendMessage({ type: 'DEV_GET_TEST_WINDOW_IDS' })
+      const response = await browser.runtime.sendMessage({ type: 'DEV_GET_TEST_WINDOW_IDS' })
       if (response.success) {
         setTestWindowCount(response.data.windowIds.length)
       }
@@ -34,7 +35,7 @@ export function DevToolsPanel({ onSuccess, onError }: DevToolsPanelProps) {
 
   useEffect(() => {
     loadTestWindowCount()
-    chrome.storage.local.get(DEV_PRO_OVERRIDE_KEY).then((result) => {
+    browser.storage.local.get(DEV_PRO_OVERRIDE_KEY).then((result) => {
       setProOverride(!!result[DEV_PRO_OVERRIDE_KEY])
     })
   }, [])
@@ -42,9 +43,9 @@ export function DevToolsPanel({ onSuccess, onError }: DevToolsPanelProps) {
   const handleProOverrideToggle = async () => {
     const newValue = !proOverride
     if (newValue) {
-      await chrome.storage.local.set({ [DEV_PRO_OVERRIDE_KEY]: true })
+      await browser.storage.local.set({ [DEV_PRO_OVERRIDE_KEY]: true })
     } else {
-      await chrome.storage.local.remove(DEV_PRO_OVERRIDE_KEY)
+      await browser.storage.local.remove(DEV_PRO_OVERRIDE_KEY)
     }
     setProOverride(newValue)
     onSuccess(newValue ? 'Pro override enabled' : 'Pro override disabled')
@@ -53,7 +54,7 @@ export function DevToolsPanel({ onSuccess, onError }: DevToolsPanelProps) {
   const handleCreateScenario = async (scenario: DevScenario) => {
     setIsLoading(scenario.id)
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'DEV_CREATE_SCENARIO',
         scenario,
       })
@@ -73,7 +74,7 @@ export function DevToolsPanel({ onSuccess, onError }: DevToolsPanelProps) {
   const handleCleanup = async () => {
     setIsLoading('cleanup')
     try {
-      const response = await chrome.runtime.sendMessage({ type: 'DEV_CLEANUP_TEST_WINDOWS' })
+      const response = await browser.runtime.sendMessage({ type: 'DEV_CLEANUP_TEST_WINDOWS' })
       if (response.success) {
         onSuccess(`Closed ${response.data.closedCount} test windows`)
         loadTestWindowCount()

--- a/src/options/components/EncryptionSetup.tsx
+++ b/src/options/components/EncryptionSetup.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useRef } from 'preact/hooks'
 import { useFocusTrap, useFocusRestore } from '@/shared/a11y'
+import { browser } from '@/shared/browser'
 
 interface EncryptionSetupProps {
   email?: string
@@ -73,7 +74,7 @@ export function EncryptionSetup({
     setErrors([])
 
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'CLOUD_SETUP_ENCRYPTION',
         password,
         tokens: pendingTokens?.tokens,

--- a/src/options/components/ProUpgrade.tsx
+++ b/src/options/components/ProUpgrade.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect } from 'preact/hooks'
 import { PRO_PRICING } from '@/shared/constants'
 import type { LicenseData } from '@/shared/licensing'
+import { browser } from '@/shared/browser'
 
 interface ProUpgradeProps {
   compact?: boolean
@@ -21,7 +22,7 @@ export function ProUpgrade({ compact = false, onLicenseActivated }: ProUpgradePr
 
   useEffect(() => {
     // Load existing license
-    chrome.runtime.sendMessage({ type: 'PRO_GET_LICENSE' }).then((response) => {
+    browser.runtime.sendMessage({ type: 'PRO_GET_LICENSE' }).then((response) => {
       if (response.success && response.data.license) {
         setLicense(response.data.license)
       }
@@ -29,7 +30,7 @@ export function ProUpgrade({ compact = false, onLicenseActivated }: ProUpgradePr
   }, [])
 
   const handleCheckout = () => {
-    chrome.runtime.sendMessage({ type: 'PRO_OPEN_CHECKOUT' })
+    browser.runtime.sendMessage({ type: 'PRO_OPEN_CHECKOUT' })
   }
 
   const handleActivate = async () => {
@@ -39,7 +40,7 @@ export function ProUpgrade({ compact = false, onLicenseActivated }: ProUpgradePr
     setError('')
 
     try {
-      const response = await chrome.runtime.sendMessage({
+      const response = await browser.runtime.sendMessage({
         type: 'PRO_ACTIVATE_LICENSE',
         licenseKey: licenseKey.trim(),
       })
@@ -63,7 +64,7 @@ export function ProUpgrade({ compact = false, onLicenseActivated }: ProUpgradePr
       return
     }
 
-    await chrome.runtime.sendMessage({ type: 'PRO_CLEAR_LICENSE' })
+    await browser.runtime.sendMessage({ type: 'PRO_CLEAR_LICENSE' })
     setLicense(null)
   }
 

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -16,6 +16,7 @@ import { SkipLink, LiveRegion } from '@/shared/a11y'
 import { useFocusTrap, useFocusRestore, useAnnounce } from '@/shared/a11y'
 import { STORAGE_KEYS } from '@/shared/constants'
 import type { MessageResponse } from '@/shared/types'
+import { browser } from '@/shared/browser'
 
 interface TabCounts {
   total: number
@@ -37,7 +38,7 @@ interface CurrentTabStatus {
 }
 
 async function sendMessage<T>(message: unknown): Promise<T | null> {
-  const response = (await chrome.runtime.sendMessage(message)) as MessageResponse
+  const response = (await browser.runtime.sendMessage(message)) as MessageResponse
   if (response.success) {
     return response.data as T
   }
@@ -158,7 +159,7 @@ export function App() {
       // (backup and cloud sync are fire-and-forget during save)
       setTimeout(async () => {
         try {
-          const result = await chrome.storage.local.get([
+          const result = await browser.storage.local.get([
             STORAGE_KEYS.LAST_BACKUP_STATUS,
             STORAGE_KEYS.LAST_SYNC_ERROR,
           ])
@@ -379,7 +380,7 @@ export function App() {
 
         {/* Settings Button */}
         <button
-          onClick={() => chrome.runtime.openOptionsPage()}
+          onClick={() => browser.runtime.openOptionsPage()}
           class="w-8 h-8 rounded-lg bg-raft-100 text-raft-600 flex items-center justify-center hover:bg-raft-200 transition-colors shrink-0"
           title="Settings"
           aria-label="Open settings"
@@ -691,7 +692,7 @@ export function App() {
 
             {/* Backup Health */}
             <div class="mt-3 pt-3 border-t border-raft-200 flex justify-center">
-              <BackupHealthBadge onNavigate={() => chrome.runtime.openOptionsPage()} />
+              <BackupHealthBadge onNavigate={() => browser.runtime.openOptionsPage()} />
             </div>
           </div>
         </div>

--- a/src/shared/browser.ts
+++ b/src/shared/browser.ts
@@ -1,0 +1,48 @@
+/**
+ * Browser API adapter.
+ *
+ * Thin alias over the WebExtensions API. Source files reference the
+ * namespaces re-exported from this module instead of touching the chrome.*
+ * global directly so that the Firefox/Edge port (Phase 2) can swap the
+ * implementation behind this single seam without touching every call site.
+ *
+ * On Chromium, every browser.* namespace resolves to the matching chrome.*
+ * namespace — both values (runtime calls) and types. Resolution is done
+ * via live property getters so that any late binding of chrome.* (e.g.
+ * test mocks installed after module load) is reflected at the call site.
+ */
+
+export namespace browser {
+  export import tabs = chrome.tabs
+  export import tabGroups = chrome.tabGroups
+  export import windows = chrome.windows
+  export import storage = chrome.storage
+  export import alarms = chrome.alarms
+  export import runtime = chrome.runtime
+  export import commands = chrome.commands
+  export import contextMenus = chrome.contextMenus
+  export import action = chrome.action
+  export import identity = chrome.identity
+}
+
+// Replace the namespace's static value captures with live getters so
+// callers always see the current chrome.* binding at access time.
+const liveNamespaces = [
+  'tabs',
+  'tabGroups',
+  'windows',
+  'storage',
+  'alarms',
+  'runtime',
+  'commands',
+  'contextMenus',
+  'action',
+  'identity',
+] as const
+for (const name of liveNamespaces) {
+  Object.defineProperty(browser, name, {
+    get: () => (chrome as Record<string, unknown>)[name],
+    configurable: true,
+    enumerable: true,
+  })
+}

--- a/src/shared/cloudSync/oauth.ts
+++ b/src/shared/cloudSync/oauth.ts
@@ -1,12 +1,13 @@
 /**
  * Google OAuth flow for Chrome extensions (MV3)
  *
- * Uses chrome.identity.launchWebAuthFlow() for the OAuth flow.
+ * Uses browser.identity.launchWebAuthFlow() for the OAuth flow.
  * This is the recommended approach for MV3 extensions.
  */
 
 import type { CloudTokens } from './types'
 import { GOOGLE_OAUTH } from '../constants'
+import { browser } from '../browser'
 
 /**
  * OAuth error with machine-readable error code (e.g., "invalid_grant")
@@ -60,7 +61,7 @@ function base64UrlEncode(buffer: Uint8Array): string {
 }
 
 /**
- * Launch Google OAuth flow using chrome.identity
+ * Launch Google OAuth flow using browser.identity
  *
  * This opens Google's consent screen and returns an authorization code.
  * We then exchange the code for tokens.
@@ -69,7 +70,7 @@ export async function launchGoogleOAuth(): Promise<OAuthResult> {
   // Clear any cached auth tokens from a previous install so Google doesn't
   // silently reuse a stale authorization that may be missing required scopes
   try {
-    await chrome.identity.clearAllCachedAuthTokens()
+    await browser.identity.clearAllCachedAuthTokens()
   } catch {
     // Best-effort — not all browsers support this
   }
@@ -79,7 +80,7 @@ export async function launchGoogleOAuth(): Promise<OAuthResult> {
   const codeChallenge = await generateCodeChallenge(codeVerifier)
 
   // Get the redirect URL for this extension
-  const redirectUrl = chrome.identity.getRedirectURL()
+  const redirectUrl = browser.identity.getRedirectURL()
 
   // Build the authorization URL
   const authUrl = new URL(GOOGLE_OAUTH.AUTH_URL)
@@ -93,7 +94,7 @@ export async function launchGoogleOAuth(): Promise<OAuthResult> {
   authUrl.searchParams.set('prompt', 'consent') // Always show consent to get refresh token
 
   // Launch the OAuth flow
-  const responseUrl = await chrome.identity.launchWebAuthFlow({
+  const responseUrl = await browser.identity.launchWebAuthFlow({
     url: authUrl.toString(),
     interactive: true,
   })
@@ -233,10 +234,10 @@ export async function revokeAccess(accessToken: string): Promise<void> {
     method: 'POST',
   })
 
-  // Also clear any cached tokens in chrome.identity
+  // Also clear any cached tokens in browser.identity
   // This is a best-effort cleanup
   try {
-    await chrome.identity.clearAllCachedAuthTokens()
+    await browser.identity.clearAllCachedAuthTokens()
   } catch {
     // Ignore errors here
   }

--- a/src/shared/cloudSync/syncEngine.ts
+++ b/src/shared/cloudSync/syncEngine.ts
@@ -37,6 +37,7 @@ import type { SyncProvider } from './providers/types'
 import * as syncQueue from './syncQueue'
 import { sessionsStorage } from '../storage'
 import { TOMBSTONE_RETENTION_MS, CLOUD_SYNC_KEYS } from '../constants'
+import { browser } from '../browser'
 
 /** Cached encryption key (in memory only, cleared on service worker termination) */
 let cachedEncryptionKey: CryptoKey | null = null
@@ -86,12 +87,12 @@ export function clearCachedTokens(): void {
 
 /** Save the set of cloud-synced session IDs to local storage */
 async function saveSyncedIds(ids: string[]): Promise<void> {
-  await chrome.storage.local.set({ [CLOUD_SYNC_KEYS.SYNCED_IDS]: ids })
+  await browser.storage.local.set({ [CLOUD_SYNC_KEYS.SYNCED_IDS]: ids })
 }
 
 /** Add a session ID to the cached cloud-synced set */
 async function addSyncedId(id: string): Promise<void> {
-  const result = await chrome.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
+  const result = await browser.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
   const ids = (result[CLOUD_SYNC_KEYS.SYNCED_IDS] as string[] | undefined) ?? []
   if (!ids.includes(id)) {
     ids.push(id)
@@ -101,7 +102,7 @@ async function addSyncedId(id: string): Promise<void> {
 
 /** Remove a session ID from the cached cloud-synced set */
 async function removeSyncedId(id: string): Promise<void> {
-  const result = await chrome.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
+  const result = await browser.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
   const ids = (result[CLOUD_SYNC_KEYS.SYNCED_IDS] as string[] | undefined) ?? []
   const filtered = ids.filter((i) => i !== id)
   await saveSyncedIds(filtered)
@@ -391,7 +392,7 @@ export async function performFullSync(): Promise<SyncResult> {
       }
 
       // 6. Handle local deletions (sessions previously synced to this device but no longer local)
-      const syncedIdsResult = await chrome.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
+      const syncedIdsResult = await browser.storage.local.get(CLOUD_SYNC_KEYS.SYNCED_IDS)
       const previouslySyncedIds = new Set(
         (syncedIdsResult[CLOUD_SYNC_KEYS.SYNCED_IDS] as string[] | undefined) ?? []
       )

--- a/src/shared/cloudSync/syncQueue.ts
+++ b/src/shared/cloudSync/syncQueue.ts
@@ -1,7 +1,7 @@
 /**
  * Persistent sync queue with exponential backoff
  *
- * The queue persists to chrome.storage to survive service worker termination.
+ * The queue persists to browser.storage to survive service worker termination.
  * Failed operations are retried with exponential backoff.
  */
 

--- a/src/shared/cloudSync/types.ts
+++ b/src/shared/cloudSync/types.ts
@@ -10,7 +10,7 @@ import type { Session } from '../types'
 export type CloudProvider = 'gdrive'
 
 /**
- * OAuth tokens stored in chrome.storage
+ * OAuth tokens stored in browser.storage
  */
 export interface CloudTokens {
   accessToken: string
@@ -33,7 +33,7 @@ export interface CloudCredentials {
 }
 
 /**
- * Encryption key material (stored encrypted in chrome.storage)
+ * Encryption key material (stored encrypted in browser.storage)
  */
 export interface EncryptionKeyData {
   /** PBKDF2 salt (base64) */

--- a/src/shared/components/BackupHealth.tsx
+++ b/src/shared/components/BackupHealth.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect } from 'preact/hooks'
 import type { BackupHealthData, HealthLevel } from '../backupHealth'
+import { browser } from '../browser'
 
 const HEALTH_COLORS: Record<HealthLevel, { icon: string; text: string }> = {
   good: { icon: 'text-green-500', text: 'text-green-700' },
@@ -25,7 +26,7 @@ export function BackupHealthBadge({ onNavigate }: BackupHealthBadgeProps) {
   useEffect(() => {
     const loadHealth = async () => {
       try {
-        const response = await chrome.runtime.sendMessage({ type: 'GET_BACKUP_HEALTH' })
+        const response = await browser.runtime.sendMessage({ type: 'GET_BACKUP_HEALTH' })
         if (response.success) {
           setHealth(response.data)
         }
@@ -72,7 +73,7 @@ export function BackupHealthBadge({ onNavigate }: BackupHealthBadgeProps) {
             if (topSuggestion.target && onNavigate) {
               onNavigate(topSuggestion.target)
             } else {
-              chrome.runtime.openOptionsPage()
+              browser.runtime.openOptionsPage()
             }
           }}
           class={`text-xs ${colors.text} hover:underline`}

--- a/src/shared/components/SyncStatus.tsx
+++ b/src/shared/components/SyncStatus.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useEffect } from 'preact/hooks'
 import { formatRelativeTime } from '../utils'
+import { browser } from '../browser'
 
 interface SyncStatusData {
   configured: boolean
@@ -29,7 +30,7 @@ export function SyncStatus({ onUnlockClick, onConnectClick }: SyncStatusProps) {
   useEffect(() => {
     const loadStatus = async () => {
       try {
-        const response = await chrome.runtime.sendMessage({ type: 'CLOUD_GET_STATUS' })
+        const response = await browser.runtime.sendMessage({ type: 'CLOUD_GET_STATUS' })
         if (response.success) {
           setStatus(response.data)
         }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,7 +2,7 @@
  * Shared constants for Raft
  */
 
-/** Storage keys for chrome.storage.local */
+/** Storage keys for browser.storage.local */
 export const STORAGE_KEYS = {
   /** User settings */
   SETTINGS: 'raft:settings',
@@ -26,7 +26,7 @@ export const STORAGE_KEYS = {
   LAST_SYNC_ERROR: 'raft:lastSyncError',
 } as const
 
-/** Storage keys for chrome.storage.sync (backup) */
+/** Storage keys for browser.storage.sync (backup) */
 export const SYNC_STORAGE_KEYS = {
   /** Manifest of synced sessions */
   MANIFEST: 'raft:sync:manifest',
@@ -48,7 +48,7 @@ export const SYNC_LIMITS = {
   QUOTA_SAFETY_MARGIN: 0.9,
 } as const
 
-/** Storage keys for chrome.storage.session (survives SW restarts, resets on browser restart) */
+/** Storage keys for browser.storage.session (survives SW restarts, resets on browser restart) */
 export const SESSION_KEYS = {
   /** Hibernation guard state for startup tab discarding */
   HIBERNATION_GUARD: 'raft:hibernationGuard',
@@ -76,7 +76,7 @@ export const SESSION_KEYS = {
  */
 export const HIBERNATION_GUARD_DURATION_MS = 30_000
 
-/** Alarm names for chrome.alarms */
+/** Alarm names for browser.alarms */
 export const ALARM_NAMES = {
   /** Periodic check for tabs to suspend */
   SUSPENSION_CHECK: 'raft:suspensionCheck',

--- a/src/shared/licensing/features.ts
+++ b/src/shared/licensing/features.ts
@@ -5,6 +5,7 @@
  */
 
 import { checkLicense } from './lemonsqueezy'
+import { browser } from '../browser'
 
 /**
  * Feature flags for different tiers
@@ -57,7 +58,7 @@ const PRO_FEATURES: FeatureFlags = {
  */
 export async function isProUser(): Promise<boolean> {
   if (import.meta.env.DEV) {
-    const result = await chrome.storage.local.get('raft:dev:proOverride')
+    const result = await browser.storage.local.get('raft:dev:proOverride')
     if (result['raft:dev:proOverride']) return true
   }
   const { isPro } = await checkLicense()

--- a/src/shared/licensing/lemonsqueezy.ts
+++ b/src/shared/licensing/lemonsqueezy.ts
@@ -12,6 +12,7 @@
 
 import { LEMONSQUEEZY, LICENSE_STORAGE_KEY } from '../constants'
 import { storage } from '../storage'
+import { browser } from '../browser'
 
 /**
  * Stored license data
@@ -112,7 +113,7 @@ export async function getStoredLicense(): Promise<LicenseData | null> {
 async function saveLicense(license: LicenseData): Promise<void> {
   await storage.set(LICENSE_STORAGE_KEY, license)
   // Also save to sync storage so it syncs across devices
-  await chrome.storage.sync.set({ [LICENSE_STORAGE_KEY]: license })
+  await browser.storage.sync.set({ [LICENSE_STORAGE_KEY]: license })
 }
 
 /**
@@ -155,14 +156,14 @@ export async function clearLicense(): Promise<void> {
     await deactivateLicense(stored.key, stored.instanceId)
   }
   await storage.remove(LICENSE_STORAGE_KEY)
-  await chrome.storage.sync.remove(LICENSE_STORAGE_KEY)
+  await browser.storage.sync.remove(LICENSE_STORAGE_KEY)
 }
 
 /**
  * Try to restore license from sync storage (for new installs)
  */
 export async function restoreLicenseFromSync(): Promise<LicenseData | null> {
-  const result = await chrome.storage.sync.get(LICENSE_STORAGE_KEY)
+  const result = await browser.storage.sync.get(LICENSE_STORAGE_KEY)
   const synced = result[LICENSE_STORAGE_KEY] as LicenseData | undefined
 
   if (synced?.key) {
@@ -296,7 +297,7 @@ export async function checkLicense(): Promise<{ isPro: boolean; email?: string }
  */
 export function openCheckoutPage(): void {
   // Open checkout in new tab
-  chrome.tabs.create({ url: LEMONSQUEEZY.CHECKOUT_URL })
+  browser.tabs.create({ url: LEMONSQUEEZY.CHECKOUT_URL })
 }
 
 /**

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -3,7 +3,7 @@
  *
  * Key insight: MV3 service workers get terminated aggressively (after ~30s of inactivity).
  * We cannot rely on in-memory state. Everything must:
- * 1. Persist to chrome.storage immediately
+ * 1. Persist to browser.storage immediately
  * 2. Reload from storage on every wake
  *
  * This wrapper provides:
@@ -15,16 +15,17 @@
 import type { Session, Folder, Settings } from './types'
 import { STORAGE_KEYS } from './constants'
 import { DEFAULT_SETTINGS } from './types'
+import { browser } from './browser'
 
 /**
- * Type-safe wrapper around chrome.storage.local
+ * Type-safe wrapper around browser.storage.local
  */
 export const storage = {
   /**
    * Get a value from storage
    */
   async get<T>(key: string, defaultValue: T): Promise<T> {
-    const result = await chrome.storage.local.get(key)
+    const result = await browser.storage.local.get(key)
     return (result[key] as T) ?? defaultValue
   },
 
@@ -32,21 +33,21 @@ export const storage = {
    * Set a value in storage
    */
   async set<T>(key: string, value: T): Promise<void> {
-    await chrome.storage.local.set({ [key]: value })
+    await browser.storage.local.set({ [key]: value })
   },
 
   /**
    * Remove a value from storage
    */
   async remove(key: string): Promise<void> {
-    await chrome.storage.local.remove(key)
+    await browser.storage.local.remove(key)
   },
 
   /**
    * Get multiple values from storage
    */
   async getMany<T extends Record<string, unknown>>(keys: (keyof T)[]): Promise<Partial<T>> {
-    const result = await chrome.storage.local.get(keys as string[])
+    const result = await browser.storage.local.get(keys as string[])
     return result as Partial<T>
   },
 
@@ -54,7 +55,7 @@ export const storage = {
    * Set multiple values atomically
    */
   async setMany(items: Record<string, unknown>): Promise<void> {
-    await chrome.storage.local.set(items)
+    await browser.storage.local.set(items)
   },
 }
 

--- a/src/shared/stores/sessionsStore.ts
+++ b/src/shared/stores/sessionsStore.ts
@@ -7,11 +7,12 @@
 
 import { create } from 'zustand'
 import type { Session, PartialRestoreSelection } from '@/shared/types'
+import { browser } from '../browser'
 
 type MessageResponse = { success: true; data?: unknown } | { success: false; error: string }
 
 async function sendMessage<T>(message: unknown): Promise<T | null> {
-  const response = (await chrome.runtime.sendMessage(message)) as MessageResponse
+  const response = (await browser.runtime.sendMessage(message)) as MessageResponse
   if (response.success) {
     return response.data as T
   }
@@ -95,7 +96,7 @@ export const useSessionsStore = create<SessionsState & SessionsActions>((set, ge
   saveCurrentWindow: async (name?: string) => {
     set({ loading: true, error: null })
     try {
-      const currentWindow = await chrome.windows.getCurrent()
+      const currentWindow = await browser.windows.getCurrent()
       const result = await sendMessage<{ session: SessionWithStats }>({
         type: 'SAVE_WINDOW',
         windowId: currentWindow.id,

--- a/src/shared/syncBackup.ts
+++ b/src/shared/syncBackup.ts
@@ -1,7 +1,7 @@
 /**
  * Sync Backup Module
  *
- * Provides automatic backup of sessions to chrome.storage.sync.
+ * Provides automatic backup of sessions to browser.storage.sync.
  * This allows sessions to survive extension reinstalls and sync across devices.
  *
  * Strategy:
@@ -16,6 +16,7 @@
 import type { Session, TabGroup } from './types'
 import { SYNC_STORAGE_KEYS, SYNC_LIMITS, SYNC_CHUNK_CONFIG } from './constants'
 import { compressToUTF16, decompressFromUTF16 } from 'lz-string'
+import { browser } from './browser'
 
 /**
  * Compress an object to a UTF-16 string for storage
@@ -95,7 +96,7 @@ interface SyncedSessionMeta {
 }
 
 /**
- * Sync manifest stored in chrome.storage.sync
+ * Sync manifest stored in browser.storage.sync
  */
 interface SyncManifest {
   /** Version for future migrations */
@@ -211,7 +212,7 @@ function getSessionKey(sessionId: string): string {
  * Load the sync manifest
  */
 async function getManifest(): Promise<SyncManifest> {
-  const result = await chrome.storage.sync.get(SYNC_STORAGE_KEYS.MANIFEST)
+  const result = await browser.storage.sync.get(SYNC_STORAGE_KEYS.MANIFEST)
   const manifest = result[SYNC_STORAGE_KEYS.MANIFEST] as SyncManifest | undefined
   return (
     manifest ?? {
@@ -228,7 +229,7 @@ async function getManifest(): Promise<SyncManifest> {
  */
 async function saveManifest(manifest: SyncManifest): Promise<void> {
   manifest.updatedAt = Date.now()
-  await chrome.storage.sync.set({ [SYNC_STORAGE_KEYS.MANIFEST]: manifest })
+  await browser.storage.sync.set({ [SYNC_STORAGE_KEYS.MANIFEST]: manifest })
 }
 
 /**
@@ -302,7 +303,7 @@ export function backupSession(session: Session): Promise<boolean> {
 
         // Remove oldest session
         const removed = manifest.sessions.splice(oldestIndex, 1)[0]
-        await chrome.storage.sync.remove(getSessionKey(removed.id))
+        await browser.storage.sync.remove(getSessionKey(removed.id))
         manifest.totalBytes -= removed.size
         available += removed.size
       }
@@ -315,7 +316,7 @@ export function backupSession(session: Session): Promise<boolean> {
 
       // Save the compressed session
       const sessionKey = getSessionKey(session.id)
-      await chrome.storage.sync.set({ [sessionKey]: compressed })
+      await browser.storage.sync.set({ [sessionKey]: compressed })
 
       // Update manifest (tabCount already computed above for projectedMeta)
       const meta: SyncedSessionMeta = {
@@ -358,7 +359,7 @@ export async function removeSessionFromSync(sessionId: string): Promise<void> {
     if (index >= 0) {
       const removed = manifest.sessions.splice(index, 1)[0]
       manifest.totalBytes -= removed.size
-      await chrome.storage.sync.remove(getSessionKey(sessionId))
+      await browser.storage.sync.remove(getSessionKey(sessionId))
       await saveManifest(manifest)
     }
   } catch (error) {
@@ -382,7 +383,7 @@ export async function restoreFromSync(): Promise<Session[]> {
     const sessions: Session[] = []
     const sessionKeys = manifest.sessions.map((s) => getSessionKey(s.id))
 
-    const result = await chrome.storage.sync.get(sessionKeys)
+    const result = await browser.storage.sync.get(sessionKeys)
 
     for (const meta of manifest.sessions) {
       const key = getSessionKey(meta.id)
@@ -442,7 +443,7 @@ export async function getSyncStatus(): Promise<{
 
   try {
     // Check for new chunked format first
-    const metaResult = await chrome.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
+    const metaResult = await browser.storage.sync.get(SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY)
     const meta = metaResult[SYNC_CHUNK_CONFIG.CHUNK_COUNT_KEY] as
       | { chunkCount: number; timestamp: number; tabCount: number }
       | undefined
@@ -453,7 +454,7 @@ export async function getSyncStatus(): Promise<{
         { length: meta.chunkCount },
         (_, i) => `${SYNC_CHUNK_CONFIG.CHUNK_PREFIX}${i}`
       )
-      const chunksResult = await chrome.storage.sync.get(chunkKeys)
+      const chunksResult = await browser.storage.sync.get(chunkKeys)
 
       const encoder = new globalThis.TextEncoder()
       for (let i = 0; i < meta.chunkCount; i++) {
@@ -467,7 +468,7 @@ export async function getSyncStatus(): Promise<{
       recoveryTabCount = meta.tabCount
     } else {
       // Fall back to legacy single-item format
-      const result = await chrome.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
+      const result = await browser.storage.sync.get(SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT)
       const stored = result[SYNC_STORAGE_KEYS.RECOVERY_SNAPSHOT]
       if (stored) {
         if (typeof stored === 'string') {
@@ -534,5 +535,5 @@ export async function shouldRestoreFromSync(localSessionCount: number): Promise<
 export async function clearSyncData(): Promise<void> {
   const manifest = await getManifest()
   const keys = [SYNC_STORAGE_KEYS.MANIFEST, ...manifest.sessions.map((s) => getSessionKey(s.id))]
-  await chrome.storage.sync.remove(keys)
+  await browser.storage.sync.remove(keys)
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,13 +3,15 @@
  *
  * These interfaces are the foundation of the extension.
  * Session and Tab structures are designed to be:
- * - Serializable to chrome.storage
+ * - Serializable to browser.storage
  * - Compatible with import/export formats
  * - Extensible for future features
  */
 
-// Re-export chrome.tabGroups.Color for convenience
-export type TabGroupColor = chrome.tabGroups.Color
+import { browser } from './browser'
+
+// Re-export browser.tabGroups.Color for convenience
+export type TabGroupColor = browser.tabGroups.Color
 
 /**
  * Represents a single browser tab
@@ -62,7 +64,7 @@ export interface Window {
   /** Whether this was the focused window */
   focused?: boolean
   /** Window state (normal, minimized, maximized, fullscreen) */
-  state?: chrome.windows.WindowState
+  state?: browser.windows.WindowState
 }
 
 /**


### PR DESCRIPTION
## Summary

Preparation for the Firefox/Edge port (Phase 2 #1) — **no functional change**.

- Add `src/shared/browser.ts`, a thin adapter that re-exports the WebExtensions namespaces Raft uses (`tabs`, `tabGroups`, `windows`, `storage`, `alarms`, `runtime`, `commands`, `contextMenus`, `action`, `identity`). On Chromium it's a pure pass-through; live property getters back each namespace so lookups always reflect the current `chrome.*` binding (important so existing test mocks keep working without touching `tests/mocks/chrome.ts`).
- Replace every `chrome.X` runtime call and `chrome.X.Y` type reference in `src/` with `browser.X` / `browser.X.Y`, plus a single `import { browser }` per file.
- Comment-only mentions were also rewritten so `git grep 'chrome\.' src/` returns only the adapter file itself.

The diff is almost entirely `s/chrome\./browser\./g` plus the new adapter file and import additions across ~26 files. Once Phase 2 swaps the adapter implementation, no call site needs to change.

**Non-goals** (deliberately out of scope, deferred to Phase 2):
- No Firefox build target.
- No API shims (e.g. no `browser.tabs.discard` fallback).
- `tests/mocks/chrome.ts` is untouched.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 problems
- [x] `pnpm test:coverage` — 745/745 passing (including the 9 oauth tests that mutate `chrome.identity` after module load — handled by the live-getter design)
- [x] `pnpm test:safety` — 55/55 passing
- [x] `pnpm build` — clean
- [x] `git grep 'chrome\.' src/` — returns only `src/shared/browser.ts`

https://claude.ai/code/session_012JBpkTyfaoEBvDdixKFX7W

---
_Generated by [Claude Code](https://claude.ai/code/session_012JBpkTyfaoEBvDdixKFX7W)_