### PR TITLE
Encrypted .raftbundle session sharing

### DIFF
--- a/src/options/components/ImportExportPanel.tsx
+++ b/src/options/components/ImportExportPanel.tsx
@@ -7,13 +7,20 @@
  */
 
 import { useState, useRef } from 'preact/hooks'
-import type { Session } from '@/shared/types'
+import { nanoid } from 'nanoid'
+import type { Session, Tab, Window } from '@/shared/types'
 import {
   importSessions,
   exportSessions,
   downloadExport,
   getFormatDisplayName,
   MAX_IMPORT_SIZE,
+  exportBundle,
+  importBundle,
+  bundleFilename,
+  generateBundlePassphrase,
+  BUNDLE_EXTENSION,
+  detectImportFormat,
   type ImportResult,
   type ExportResult,
 } from '@/shared/importExport'
@@ -36,6 +43,31 @@ type ExportState =
   | { status: 'success'; result: ExportResult }
   | { status: 'error'; message: string }
 
+/** Modal for the encrypted-bundle export flow. Shows passphrase + download. */
+type BundleExportDialog =
+  | { status: 'closed' }
+  | {
+      status: 'open'
+      session: Session
+      passphrase: string
+      blob: globalThis.Blob
+      filename: string
+      passphraseCopied: boolean
+      downloaded: boolean
+    }
+
+/** Modal for the encrypted-bundle import flow. Passphrase entry → tab picker. */
+type BundleImportDialog =
+  | { status: 'closed' }
+  | { status: 'awaitingPassphrase'; file: globalThis.File; passphrase: string; error?: string }
+  | { status: 'decrypting'; file: globalThis.File }
+  | {
+      status: 'choosing'
+      session: Session
+      // tab id -> selected
+      selected: Set<string>
+    }
+
 export function ImportExportPanel({
   sessions,
   onImportComplete,
@@ -45,6 +77,8 @@ export function ImportExportPanel({
   const [importState, setImportState] = useState<ImportState>({ status: 'idle' })
   const [exportState, setExportState] = useState<ExportState>({ status: 'idle' })
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(new Set())
+  const [bundleExport, setBundleExport] = useState<BundleExportDialog>({ status: 'closed' })
+  const [bundleImport, setBundleImport] = useState<BundleImportDialog>({ status: 'closed' })
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleFileSelect = async (e: globalThis.Event) => {
@@ -64,10 +98,26 @@ export function ImportExportPanel({
       return
     }
 
+    // Encrypted bundles need a passphrase before they can be parsed. Detect by
+    // extension or by sniffing the JSON envelope shape and route to the
+    // bundle-import flow instead of the auto-detect parser.
+    if (file.name.toLowerCase().endsWith(BUNDLE_EXTENSION)) {
+      setBundleImport({ status: 'awaitingPassphrase', file, passphrase: '' })
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      return
+    }
+
     setImportState({ status: 'loading' })
 
     try {
       const content = await file.text()
+
+      if (detectImportFormat(content) === 'raftbundle') {
+        setBundleImport({ status: 'awaitingPassphrase', file, passphrase: '' })
+        setImportState({ status: 'idle' })
+        return
+      }
+
       const result = importSessions(content)
 
       if (!result.success && result.errors.length > 0) {
@@ -108,6 +158,177 @@ export function ImportExportPanel({
       fileInputRef.current.value = ''
     }
   }
+
+  const handleEncryptedExport = async (sessionId: string) => {
+    const sessionWithStats = sessions.find((s) => s.id === sessionId)
+    if (!sessionWithStats) return
+
+    // Strip the UI-only stats wrapper before serializing.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { stats: _stats, ...session } = sessionWithStats
+    const target = session as Session
+
+    try {
+      const passphrase = generateBundlePassphrase()
+      const blob = await exportBundle(target, passphrase)
+      setBundleExport({
+        status: 'open',
+        session: target,
+        passphrase,
+        blob,
+        filename: bundleFilename(target),
+        passphraseCopied: false,
+        downloaded: false,
+      })
+    } catch (err) {
+      setExportState({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Failed to encrypt bundle',
+      })
+    }
+  }
+
+  const handleCopyPassphrase = async () => {
+    if (bundleExport.status !== 'open') return
+    try {
+      await globalThis.navigator.clipboard.writeText(bundleExport.passphrase)
+      setBundleExport({ ...bundleExport, passphraseCopied: true })
+    } catch {
+      // Clipboard can fail in restricted contexts; the passphrase is still on screen.
+    }
+  }
+
+  const handleDownloadBundle = () => {
+    if (bundleExport.status !== 'open') return
+    const url = URL.createObjectURL(bundleExport.blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = bundleExport.filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+    setBundleExport({ ...bundleExport, downloaded: true })
+    onExportComplete?.()
+  }
+
+  const closeBundleExport = () => setBundleExport({ status: 'closed' })
+
+  const handleBundleDecrypt = async () => {
+    if (bundleImport.status !== 'awaitingPassphrase') return
+    const { file, passphrase } = bundleImport
+
+    if (!passphrase) {
+      setBundleImport({ ...bundleImport, error: 'Enter the passphrase to continue.' })
+      return
+    }
+
+    setBundleImport({ status: 'decrypting', file })
+
+    try {
+      const session = await importBundle(file, passphrase)
+      const allTabIds = new Set<string>(session.windows.flatMap((w) => w.tabs.map((t) => t.id)))
+      setBundleImport({ status: 'choosing', session, selected: allTabIds })
+    } catch (err) {
+      setBundleImport({
+        status: 'awaitingPassphrase',
+        file,
+        passphrase,
+        error: err instanceof Error ? err.message : 'Failed to decrypt bundle',
+      })
+    }
+  }
+
+  const toggleBundleTab = (tabId: string) => {
+    if (bundleImport.status !== 'choosing') return
+    const next = new Set(bundleImport.selected)
+    if (next.has(tabId)) next.delete(tabId)
+    else next.add(tabId)
+    setBundleImport({ ...bundleImport, selected: next })
+  }
+
+  const toggleAllBundleTabs = (select: boolean) => {
+    if (bundleImport.status !== 'choosing') return
+    if (select) {
+      const all = new Set<string>(
+        bundleImport.session.windows.flatMap((w) => w.tabs.map((t) => t.id))
+      )
+      setBundleImport({ ...bundleImport, selected: all })
+    } else {
+      setBundleImport({ ...bundleImport, selected: new Set() })
+    }
+  }
+
+  const handleConfirmBundleImport = async () => {
+    if (bundleImport.status !== 'choosing') return
+    const { session, selected } = bundleImport
+
+    // Filter the decrypted session down to selected tabs. Drop empty windows
+    // and tab groups whose tabs were all deselected so the imported session
+    // doesn't carry orphan groups.
+    const newWindows: Window[] = []
+    for (const window of session.windows) {
+      const keptTabs: Tab[] = window.tabs
+        .filter((t) => selected.has(t.id))
+        .map((t, i) => ({ ...t, index: i }))
+      if (keptTabs.length === 0) continue
+
+      const usedGroupIds = new Set(keptTabs.map((t) => t.groupId).filter(Boolean) as string[])
+      const keptGroups = window.tabGroups.filter((g) => usedGroupIds.has(g.id))
+      newWindows.push({ ...window, id: nanoid(), tabs: keptTabs, tabGroups: keptGroups })
+    }
+
+    if (newWindows.length === 0) {
+      setBundleImport({
+        status: 'choosing',
+        session,
+        selected,
+      })
+      setImportState({ status: 'error', message: 'Select at least one tab to import.' })
+      return
+    }
+
+    // Always assign a fresh session ID so a recipient with an existing copy
+    // doesn't get their version silently overwritten.
+    const importedSession: Session = {
+      ...session,
+      id: nanoid(),
+      windows: newWindows,
+      source: 'import',
+      updatedAt: Date.now(),
+    }
+
+    try {
+      const existing = await sessionsStorage.getAll()
+      await sessionsStorage.saveAll([...existing, importedSession])
+
+      const tabsImported = newWindows.reduce((sum, w) => sum + w.tabs.length, 0)
+      const result: ImportResult = {
+        success: true,
+        sessions: [importedSession],
+        errors: [],
+        warnings: [],
+        stats: {
+          totalEntries: tabsImported,
+          validUrls: tabsImported,
+          skippedUrls: 0,
+          sessionsCreated: 1,
+          tabsImported,
+        },
+        format: 'raftbundle',
+      }
+      setImportState({ status: 'success', result })
+      setBundleImport({ status: 'closed' })
+      onImportComplete()
+    } catch (err) {
+      setImportState({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Failed to save imported session',
+      })
+    }
+  }
+
+  const closeBundleImport = () => setBundleImport({ status: 'closed' })
 
   const handleExport = (format: 'json' | 'text') => {
     const sessionIds = selectedSessionIds.size > 0 ? Array.from(selectedSessionIds) : undefined
@@ -156,300 +377,551 @@ export function ImportExportPanel({
   }
 
   return (
-    <div class="bg-white rounded-lg shadow-sm border border-raft-200 mb-4">
-      {/* Header - always visible */}
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-raft-50 transition-colors rounded-lg"
-        aria-expanded={isExpanded}
-        aria-controls="import-export-content"
-      >
-        <span class="font-medium text-raft-900">Import / Export</span>
-        <svg
-          class={`w-5 h-5 text-raft-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
+    <>
+      <div class="bg-white rounded-lg shadow-sm border border-raft-200 mb-4">
+        {/* Header - always visible */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-raft-50 transition-colors rounded-lg"
+          aria-expanded={isExpanded}
+          aria-controls="import-export-content"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
+          <span class="font-medium text-raft-900">Import / Export</span>
+          <svg
+            class={`w-5 h-5 text-raft-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
 
-      {/* Expandable content */}
-      {isExpanded && (
-        <div id="import-export-content" class="px-4 pb-4 border-t border-raft-100">
-          {/* Import Section */}
-          <div class="mt-4">
-            <h3 class="text-sm font-medium text-raft-700 mb-2">Import Sessions</h3>
-            <p class="text-xs text-raft-500 mb-3">
-              Supports OneTab, Session Buddy, Tab Session Manager, Toby, and Raft backups. Import
-              formats are based on best available documentation. If your import doesn't work, please{' '}
-              <a
-                href="https://github.com/raftapp/raft/issues"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="underline hover:text-raft-700"
-              >
-                let us know
-              </a>{' '}
-              and we'll prioritize a fix.
-            </p>
+        {/* Expandable content */}
+        {isExpanded && (
+          <div id="import-export-content" class="px-4 pb-4 border-t border-raft-100">
+            {/* Import Section */}
+            <div class="mt-4">
+              <h3 class="text-sm font-medium text-raft-700 mb-2">Import Sessions</h3>
+              <p class="text-xs text-raft-500 mb-3">
+                Supports OneTab, Session Buddy, Tab Session Manager, Toby, and Raft backups. Import
+                formats are based on best available documentation. If your import doesn't work,
+                please{' '}
+                <a
+                  href="https://github.com/raftapp/raft/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="underline hover:text-raft-700"
+                >
+                  let us know
+                </a>{' '}
+                and we'll prioritize a fix.
+              </p>
 
-            <label class="inline-block">
-              <span class="sr-only">Choose file to import</span>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".json,.txt,text/plain,application/json"
-                onChange={handleFileSelect}
-                class="sr-only"
-                aria-describedby="import-formats"
-              />
-              <span
-                role="button"
-                tabIndex={importState.status === 'loading' ? -1 : 0}
-                onClick={() => fileInputRef.current?.click()}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    fileInputRef.current?.click()
-                  }
-                }}
-                class={`inline-block px-4 py-2 text-sm bg-raft-100 text-raft-700 rounded-lg hover:bg-raft-200 transition-colors cursor-pointer ${
-                  importState.status === 'loading' ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-              >
-                {importState.status === 'loading' ? 'Importing...' : 'Choose File...'}
+              <label class="inline-block">
+                <span class="sr-only">Choose file to import</span>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json,.txt,.raftbundle,text/plain,application/json"
+                  onChange={handleFileSelect}
+                  class="sr-only"
+                  aria-describedby="import-formats"
+                />
+                <span
+                  role="button"
+                  tabIndex={importState.status === 'loading' ? -1 : 0}
+                  onClick={() => fileInputRef.current?.click()}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      fileInputRef.current?.click()
+                    }
+                  }}
+                  class={`inline-block px-4 py-2 text-sm bg-raft-100 text-raft-700 rounded-lg hover:bg-raft-200 transition-colors cursor-pointer ${
+                    importState.status === 'loading' ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                >
+                  {importState.status === 'loading' ? 'Importing...' : 'Choose File...'}
+                </span>
+              </label>
+              <span id="import-formats" class="sr-only">
+                Accepts JSON and text files from OneTab, Session Buddy, Tab Session Manager, Toby,
+                and Raft
               </span>
-            </label>
-            <span id="import-formats" class="sr-only">
-              Accepts JSON and text files from OneTab, Session Buddy, Tab Session Manager, Toby, and
-              Raft
-            </span>
 
-            {/* Import Status */}
-            {importState.status === 'success' && (
-              <div role="status" class="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg">
-                <div class="flex items-start justify-between">
-                  <div>
-                    <p class="text-sm text-green-800 font-medium">Import successful!</p>
-                    <p class="text-xs text-green-700 mt-1">
-                      {importState.result.format && (
-                        <>Format: {getFormatDisplayName(importState.result.format)} &middot; </>
-                      )}
-                      {importState.result.stats.sessionsCreated} session
-                      {importState.result.stats.sessionsCreated !== 1 ? 's' : ''} &middot;{' '}
-                      {importState.result.stats.tabsImported} tab
-                      {importState.result.stats.tabsImported !== 1 ? 's' : ''}
-                    </p>
-                    {importState.result.warnings.length > 0 && (
-                      <p class="text-xs text-yellow-700 mt-1">
-                        {importState.result.warnings.length} warning
-                        {importState.result.warnings.length !== 1 ? 's' : ''} (
-                        {importState.result.stats.skippedUrls} skipped)
+              {/* Import Status */}
+              {importState.status === 'success' && (
+                <div role="status" class="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg">
+                  <div class="flex items-start justify-between">
+                    <div>
+                      <p class="text-sm text-green-800 font-medium">Import successful!</p>
+                      <p class="text-xs text-green-700 mt-1">
+                        {importState.result.format && (
+                          <>Format: {getFormatDisplayName(importState.result.format)} &middot; </>
+                        )}
+                        {importState.result.stats.sessionsCreated} session
+                        {importState.result.stats.sessionsCreated !== 1 ? 's' : ''} &middot;{' '}
+                        {importState.result.stats.tabsImported} tab
+                        {importState.result.stats.tabsImported !== 1 ? 's' : ''}
                       </p>
+                      {importState.result.warnings.length > 0 && (
+                        <p class="text-xs text-yellow-700 mt-1">
+                          {importState.result.warnings.length} warning
+                          {importState.result.warnings.length !== 1 ? 's' : ''} (
+                          {importState.result.stats.skippedUrls} skipped)
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      onClick={dismissImportStatus}
+                      class="text-green-600 hover:text-green-800"
+                      aria-label="Dismiss import success message"
+                    >
+                      <svg
+                        class="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {importState.status === 'error' && (
+                <div role="alert" class="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
+                  <div class="flex items-start justify-between">
+                    <div>
+                      <p class="text-sm text-red-800 font-medium">Import failed</p>
+                      <p class="text-xs text-red-700 mt-1">{importState.message}</p>
+                    </div>
+                    <button
+                      onClick={dismissImportStatus}
+                      class="text-red-600 hover:text-red-800"
+                      aria-label="Dismiss import error message"
+                    >
+                      <svg
+                        class="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Export Section */}
+            <div class="mt-6 pt-4 border-t border-raft-100">
+              <h3 class="text-sm font-medium text-raft-700 mb-2">Export Sessions</h3>
+
+              {sessions.length === 0 ? (
+                <p class="text-xs text-raft-500">No sessions to export.</p>
+              ) : (
+                <>
+                  <p class="text-xs text-raft-500 mb-3">
+                    Select sessions to export, or export all if none selected.
+                  </p>
+
+                  {/* Session selection */}
+                  <div class="max-h-40 overflow-y-auto border border-raft-200 rounded-lg mb-3">
+                    {sessions.map((session) => (
+                      <div
+                        key={session.id}
+                        class="flex items-center gap-2 px-3 py-2 hover:bg-raft-50 border-b border-raft-100 last:border-b-0"
+                      >
+                        <label class="flex items-center gap-2 cursor-pointer flex-1 min-w-0">
+                          <input
+                            type="checkbox"
+                            checked={selectedSessionIds.has(session.id)}
+                            onChange={() => toggleSession(session.id)}
+                            class="w-4 h-4 rounded border-raft-300 text-raft-600 focus:ring-raft-500"
+                          />
+                          <span class="text-sm text-raft-700 truncate flex-1">{session.name}</span>
+                          <span class="text-xs text-raft-400">
+                            {session.stats.tabs} tab{session.stats.tabs !== 1 ? 's' : ''}
+                          </span>
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => handleEncryptedExport(session.id)}
+                          class="text-xs text-raft-600 hover:text-raft-800 underline whitespace-nowrap"
+                          title="Export this session as an encrypted .raftbundle file"
+                        >
+                          Encrypt & share
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Selection controls */}
+                  <div class="flex items-center gap-2 mb-3">
+                    <button onClick={selectAll} class="text-xs text-raft-600 hover:text-raft-700">
+                      Select All
+                    </button>
+                    <span class="text-raft-300">|</span>
+                    <button
+                      onClick={clearSelection}
+                      class="text-xs text-raft-500 hover:text-raft-700"
+                    >
+                      Clear
+                    </button>
+                    {selectedSessionIds.size > 0 && (
+                      <span class="text-xs text-raft-400 ml-auto">
+                        {selectedSessionIds.size} selected
+                      </span>
                     )}
                   </div>
-                  <button
-                    onClick={dismissImportStatus}
-                    class="text-green-600 hover:text-green-800"
-                    aria-label="Dismiss import success message"
-                  >
-                    <svg
-                      class="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            )}
 
-            {importState.status === 'error' && (
-              <div role="alert" class="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-                <div class="flex items-start justify-between">
-                  <div>
-                    <p class="text-sm text-red-800 font-medium">Import failed</p>
-                    <p class="text-xs text-red-700 mt-1">{importState.message}</p>
+                  {/* Export buttons */}
+                  <div class="flex gap-2">
+                    <button
+                      onClick={() => handleExport('json')}
+                      class="px-4 py-2 text-sm bg-raft-600 text-white rounded-lg hover:bg-raft-700 transition-colors"
+                    >
+                      Export JSON
+                    </button>
+                    <button
+                      onClick={() => handleExport('text')}
+                      class="px-4 py-2 text-sm border border-raft-300 text-raft-700 rounded-lg hover:bg-raft-50 transition-colors"
+                    >
+                      Export Text
+                    </button>
                   </div>
-                  <button
-                    onClick={dismissImportStatus}
-                    class="text-red-600 hover:text-red-800"
-                    aria-label="Dismiss import error message"
-                  >
-                    <svg
-                      class="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
+
+                  {/* Export Status */}
+                  {exportState.status === 'success' && (
+                    <div
+                      role="status"
+                      class="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg"
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Export Section */}
-          <div class="mt-6 pt-4 border-t border-raft-100">
-            <h3 class="text-sm font-medium text-raft-700 mb-2">Export Sessions</h3>
-
-            {sessions.length === 0 ? (
-              <p class="text-xs text-raft-500">No sessions to export.</p>
-            ) : (
-              <>
-                <p class="text-xs text-raft-500 mb-3">
-                  Select sessions to export, or export all if none selected.
-                </p>
-
-                {/* Session selection */}
-                <div class="max-h-40 overflow-y-auto border border-raft-200 rounded-lg mb-3">
-                  {sessions.map((session) => (
-                    <label
-                      key={session.id}
-                      class="flex items-center gap-2 px-3 py-2 hover:bg-raft-50 cursor-pointer border-b border-raft-100 last:border-b-0"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedSessionIds.has(session.id)}
-                        onChange={() => toggleSession(session.id)}
-                        class="w-4 h-4 rounded border-raft-300 text-raft-600 focus:ring-raft-500"
-                      />
-                      <span class="text-sm text-raft-700 truncate flex-1">{session.name}</span>
-                      <span class="text-xs text-raft-400">
-                        {session.stats.tabs} tab{session.stats.tabs !== 1 ? 's' : ''}
-                      </span>
-                    </label>
-                  ))}
-                </div>
-
-                {/* Selection controls */}
-                <div class="flex items-center gap-2 mb-3">
-                  <button onClick={selectAll} class="text-xs text-raft-600 hover:text-raft-700">
-                    Select All
-                  </button>
-                  <span class="text-raft-300">|</span>
-                  <button
-                    onClick={clearSelection}
-                    class="text-xs text-raft-500 hover:text-raft-700"
-                  >
-                    Clear
-                  </button>
-                  {selectedSessionIds.size > 0 && (
-                    <span class="text-xs text-raft-400 ml-auto">
-                      {selectedSessionIds.size} selected
-                    </span>
+                      <div class="flex items-start justify-between">
+                        <div>
+                          <p class="text-sm text-green-800 font-medium">Export complete!</p>
+                          <p class="text-xs text-green-700 mt-1">
+                            {exportState.result.stats.sessionsExported} session
+                            {exportState.result.stats.sessionsExported !== 1
+                              ? 's'
+                              : ''} &middot; {exportState.result.stats.tabsExported} tab
+                            {exportState.result.stats.tabsExported !== 1 ? 's' : ''}
+                          </p>
+                        </div>
+                        <button
+                          onClick={dismissExportStatus}
+                          class="text-green-600 hover:text-green-800"
+                          aria-label="Dismiss export success message"
+                        >
+                          <svg
+                            class="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
                   )}
-                </div>
 
-                {/* Export buttons */}
-                <div class="flex gap-2">
-                  <button
-                    onClick={() => handleExport('json')}
-                    class="px-4 py-2 text-sm bg-raft-600 text-white rounded-lg hover:bg-raft-700 transition-colors"
-                  >
-                    Export JSON
-                  </button>
-                  <button
-                    onClick={() => handleExport('text')}
-                    class="px-4 py-2 text-sm border border-raft-300 text-raft-700 rounded-lg hover:bg-raft-50 transition-colors"
-                  >
-                    Export Text
-                  </button>
-                </div>
-
-                {/* Export Status */}
-                {exportState.status === 'success' && (
-                  <div
-                    role="status"
-                    class="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg"
-                  >
-                    <div class="flex items-start justify-between">
-                      <div>
-                        <p class="text-sm text-green-800 font-medium">Export complete!</p>
-                        <p class="text-xs text-green-700 mt-1">
-                          {exportState.result.stats.sessionsExported} session
-                          {exportState.result.stats.sessionsExported !== 1 ? 's' : ''} &middot;{' '}
-                          {exportState.result.stats.tabsExported} tab
-                          {exportState.result.stats.tabsExported !== 1 ? 's' : ''}
-                        </p>
-                      </div>
-                      <button
-                        onClick={dismissExportStatus}
-                        class="text-green-600 hover:text-green-800"
-                        aria-label="Dismiss export success message"
-                      >
-                        <svg
-                          class="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
+                  {exportState.status === 'error' && (
+                    <div role="alert" class="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
+                      <div class="flex items-start justify-between">
+                        <div>
+                          <p class="text-sm text-red-800 font-medium">Export failed</p>
+                          <p class="text-xs text-red-700 mt-1">{exportState.message}</p>
+                        </div>
+                        <button
+                          onClick={dismissExportStatus}
+                          class="text-red-600 hover:text-red-800"
+                          aria-label="Dismiss export error message"
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M6 18L18 6M6 6l12 12"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                )}
-
-                {exportState.status === 'error' && (
-                  <div role="alert" class="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-                    <div class="flex items-start justify-between">
-                      <div>
-                        <p class="text-sm text-red-800 font-medium">Export failed</p>
-                        <p class="text-xs text-red-700 mt-1">{exportState.message}</p>
+                          <svg
+                            class="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
                       </div>
-                      <button
-                        onClick={dismissExportStatus}
-                        class="text-red-600 hover:text-red-800"
-                        aria-label="Dismiss export error message"
-                      >
-                        <svg
-                          class="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M6 18L18 6M6 6l12 12"
-                          />
-                        </svg>
-                      </button>
                     </div>
-                  </div>
-                )}
-              </>
-            )}
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Encrypted bundle export dialog */}
+      {bundleExport.status === 'open' && (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bundle-export-title"
+        >
+          <div class="bg-white rounded-lg shadow-lg border border-raft-200 max-w-md w-full p-6">
+            <h2 id="bundle-export-title" class="text-lg font-semibold text-raft-900 mb-1">
+              Encrypted bundle for "{bundleExport.session.name}"
+            </h2>
+            <p class="text-sm text-raft-600 mb-4">
+              We've generated a one-time passphrase. The bundle is encrypted with AES-256-GCM and
+              PBKDF2 (600,000 iterations) — without this passphrase, no one (including us) can read
+              it.
+            </p>
+
+            <div class="bg-raft-50 border border-raft-200 rounded-lg p-3 mb-3">
+              <p class="text-xs text-raft-500 mb-1">Passphrase (shown once)</p>
+              <code class="block text-sm font-mono text-raft-900 break-all select-all">
+                {bundleExport.passphrase}
+              </code>
+            </div>
+
+            <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-4">
+              <p class="text-sm text-yellow-800 font-medium">Share through a different channel</p>
+              <p class="text-xs text-yellow-700 mt-1">
+                Send the passphrase through a different channel than the file (e.g. text the file,
+                call with the passphrase). End-to-end encryption only protects you if the two halves
+                don't travel together.
+              </p>
+            </div>
+
+            <div class="flex flex-wrap gap-2 mb-2">
+              <button
+                type="button"
+                onClick={handleCopyPassphrase}
+                class="px-4 py-2 text-sm bg-raft-100 text-raft-700 rounded-lg hover:bg-raft-200 transition-colors"
+              >
+                {bundleExport.passphraseCopied ? 'Passphrase copied!' : 'Copy passphrase'}
+              </button>
+              <button
+                type="button"
+                onClick={handleDownloadBundle}
+                class="px-4 py-2 text-sm bg-raft-600 text-white rounded-lg hover:bg-raft-700 transition-colors"
+              >
+                {bundleExport.downloaded ? 'Download again' : 'Download bundle'}
+              </button>
+            </div>
+            <p class="text-xs text-raft-500 mb-4">
+              Two separate clicks on purpose — so you don't accidentally share both at once.
+            </p>
+
+            <button
+              type="button"
+              onClick={closeBundleExport}
+              class="text-sm text-raft-600 hover:text-raft-800 underline"
+            >
+              Done
+            </button>
           </div>
         </div>
       )}
-    </div>
+
+      {/* Encrypted bundle import dialog: passphrase entry */}
+      {bundleImport.status === 'awaitingPassphrase' && (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bundle-import-title"
+        >
+          <div class="bg-white rounded-lg shadow-lg border border-raft-200 max-w-md w-full p-6">
+            <h2 id="bundle-import-title" class="text-lg font-semibold text-raft-900 mb-1">
+              Decrypt {bundleImport.file.name}
+            </h2>
+            <p class="text-sm text-raft-600 mb-4">
+              Enter the passphrase the sender shared with you out-of-band.
+            </p>
+
+            <input
+              type="password"
+              value={bundleImport.passphrase}
+              onInput={(e) =>
+                setBundleImport({
+                  ...bundleImport,
+                  passphrase: (e.target as HTMLInputElement).value,
+                  error: undefined,
+                })
+              }
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  void handleBundleDecrypt()
+                }
+              }}
+              placeholder="Passphrase"
+              ref={(el) => {
+                // Focus the passphrase field when the dialog mounts so the user
+                // can type immediately. eslint complains about `autoFocus` so we
+                // do this via ref instead.
+                if (el && document.activeElement !== el) el.focus()
+              }}
+              class="w-full px-3 py-2 border border-raft-300 rounded-lg text-sm mb-2 focus:ring-2 focus:ring-raft-500 focus:border-raft-500"
+            />
+
+            {bundleImport.error && (
+              <p role="alert" class="text-xs text-red-700 mb-2">
+                {bundleImport.error}
+              </p>
+            )}
+
+            <div class="flex gap-2">
+              <button
+                type="button"
+                onClick={handleBundleDecrypt}
+                class="px-4 py-2 text-sm bg-raft-600 text-white rounded-lg hover:bg-raft-700 transition-colors"
+              >
+                Decrypt
+              </button>
+              <button
+                type="button"
+                onClick={closeBundleImport}
+                class="px-4 py-2 text-sm border border-raft-300 text-raft-700 rounded-lg hover:bg-raft-50 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {bundleImport.status === 'decrypting' && (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div class="bg-white rounded-lg shadow-lg border border-raft-200 px-6 py-4">
+            <p class="text-sm text-raft-700">Decrypting bundle…</p>
+          </div>
+        </div>
+      )}
+
+      {/* Encrypted bundle import dialog: tab picker */}
+      {bundleImport.status === 'choosing' && (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bundle-choose-title"
+        >
+          <div class="bg-white rounded-lg shadow-lg border border-raft-200 max-w-2xl w-full p-6 max-h-[80vh] flex flex-col">
+            <h2 id="bundle-choose-title" class="text-lg font-semibold text-raft-900 mb-1">
+              Pick tabs to import from "{bundleImport.session.name}"
+            </h2>
+            <p class="text-sm text-raft-600 mb-3">
+              Decrypted successfully. Choose which tabs to add to your library — the original
+              session isn't touched.
+            </p>
+
+            <div class="flex items-center gap-2 mb-2">
+              <button
+                type="button"
+                onClick={() => toggleAllBundleTabs(true)}
+                class="text-xs text-raft-600 hover:text-raft-800 underline"
+              >
+                Select all
+              </button>
+              <span class="text-raft-300">|</span>
+              <button
+                type="button"
+                onClick={() => toggleAllBundleTabs(false)}
+                class="text-xs text-raft-500 hover:text-raft-700 underline"
+              >
+                Clear
+              </button>
+              <span class="text-xs text-raft-400 ml-auto">
+                {bundleImport.selected.size} selected
+              </span>
+            </div>
+
+            <div class="flex-1 overflow-y-auto border border-raft-200 rounded-lg mb-3">
+              {bundleImport.session.windows.map((window, wIdx) => (
+                <div key={window.id} class="border-b border-raft-100 last:border-b-0">
+                  <p class="text-xs font-medium text-raft-500 px-3 py-2 bg-raft-50">
+                    Window {wIdx + 1} ({window.tabs.length} tab{window.tabs.length !== 1 ? 's' : ''}
+                    )
+                  </p>
+                  {window.tabs.map((tab) => (
+                    <label
+                      key={tab.id}
+                      class="flex items-center gap-2 px-3 py-2 hover:bg-raft-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={bundleImport.selected.has(tab.id)}
+                        onChange={() => toggleBundleTab(tab.id)}
+                        class="w-4 h-4 rounded border-raft-300 text-raft-600 focus:ring-raft-500"
+                      />
+                      <span class="text-sm text-raft-700 truncate flex-1" title={tab.url}>
+                        {tab.title || tab.url}
+                      </span>
+                      {tab.pinned && (
+                        <span class="text-xs text-raft-400" aria-label="pinned">
+                          📌
+                        </span>
+                      )}
+                    </label>
+                  ))}
+                </div>
+              ))}
+            </div>
+
+            <div class="flex gap-2">
+              <button
+                type="button"
+                onClick={handleConfirmBundleImport}
+                disabled={bundleImport.selected.size === 0}
+                class="px-4 py-2 text-sm bg-raft-600 text-white rounded-lg hover:bg-raft-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Import {bundleImport.selected.size} tab
+                {bundleImport.selected.size !== 1 ? 's' : ''}
+              </button>
+              <button
+                type="button"
+                onClick={closeBundleImport}
+                class="px-4 py-2 text-sm border border-raft-300 text-raft-700 rounded-lg hover:bg-raft-50 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/src/options/components/ImportExportPanel.tsx
+++ b/src/options/components/ImportExportPanel.tsx
@@ -432,7 +432,13 @@ export function ImportExportPanel({
                 <span
                   role="button"
                   tabIndex={importState.status === 'loading' ? -1 : 0}
-                  onClick={() => fileInputRef.current?.click()}
+                  onClick={(e) => {
+                    // The wrapping <label> also forwards clicks to the file
+                    // input, so without stopPropagation the picker opens
+                    // twice.
+                    e.stopPropagation()
+                    fileInputRef.current?.click()
+                  }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault()

--- a/src/options/components/ImportExportPanel.tsx
+++ b/src/options/components/ImportExportPanel.tsx
@@ -419,39 +419,24 @@ export function ImportExportPanel({
                 and we'll prioritize a fix.
               </p>
 
-              <label class="inline-block">
-                <span class="sr-only">Choose file to import</span>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".json,.txt,.raftbundle,text/plain,application/json"
-                  onChange={handleFileSelect}
-                  class="sr-only"
-                  aria-describedby="import-formats"
-                />
-                <span
-                  role="button"
-                  tabIndex={importState.status === 'loading' ? -1 : 0}
-                  onClick={(e) => {
-                    // The wrapping <label> also forwards clicks to the file
-                    // input, so without stopPropagation the picker opens
-                    // twice.
-                    e.stopPropagation()
-                    fileInputRef.current?.click()
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      fileInputRef.current?.click()
-                    }
-                  }}
-                  class={`inline-block px-4 py-2 text-sm bg-raft-100 text-raft-700 rounded-lg hover:bg-raft-200 transition-colors cursor-pointer ${
-                    importState.status === 'loading' ? 'opacity-50 cursor-not-allowed' : ''
-                  }`}
-                >
-                  {importState.status === 'loading' ? 'Importing...' : 'Choose File...'}
-                </span>
-              </label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,.txt,.raftbundle,text/plain,application/json"
+                onChange={handleFileSelect}
+                class="sr-only"
+                aria-hidden="true"
+                tabIndex={-1}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={importState.status === 'loading'}
+                aria-describedby="import-formats"
+                class="inline-block px-4 py-2 text-sm bg-raft-100 text-raft-700 rounded-lg hover:bg-raft-200 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {importState.status === 'loading' ? 'Importing...' : 'Choose File...'}
+              </button>
               <span id="import-formats" class="sr-only">
                 Accepts JSON and text files from OneTab, Session Buddy, Tab Session Manager, Toby,
                 and Raft

--- a/src/options/components/ImportExportPanel.tsx
+++ b/src/options/components/ImportExportPanel.tsx
@@ -694,7 +694,7 @@ export function ImportExportPanel({
           aria-modal="true"
           aria-labelledby="bundle-export-title"
         >
-          <div class="bg-white rounded-lg shadow-lg border border-raft-200 max-w-md w-full p-6">
+          <div class="bg-white rounded-lg shadow-lg border border-raft-200 max-w-lg w-full p-6">
             <h2 id="bundle-export-title" class="text-lg font-semibold text-raft-900 mb-1">
               Encrypted bundle for "{bundleExport.session.name}"
             </h2>

--- a/src/shared/importExport/bundle.ts
+++ b/src/shared/importExport/bundle.ts
@@ -309,8 +309,35 @@ export function generateBundlePassphrase(): string {
     'zephyr',
   ]
 
-  const buf = crypto.getRandomValues(new Uint32Array(6))
-  const picks = Array.from(buf, (n) => words[n % words.length])
-  const num = crypto.getRandomValues(new Uint32Array(1))[0] % 10000
+  const picks = Array.from({ length: 6 }, () => words[unbiasedRandomInt(words.length)])
+  const num = unbiasedRandomInt(10_000)
   return `${picks.join('-')}-${num.toString().padStart(4, '0')}`
+}
+
+/**
+ * Generate an unbiased integer in `[0, max)` from a CSPRNG.
+ *
+ * Naively doing `crypto.getRandomValues(...) % max` is biased whenever
+ * `2^32 % max !== 0` — the lower buckets get slightly more probability
+ * than the higher ones. Rejection sampling fixes this: discard any
+ * draw that falls in the "unfair" top slice, so the remaining range
+ * is an exact multiple of `max` and the modulo is uniform.
+ *
+ * For the values we use (120-word list, 10_000) the rejection rate is
+ * effectively zero (< 1 in ~36M), so this loop is virtually always
+ * one iteration.
+ */
+function unbiasedRandomInt(max: number): number {
+  if (max <= 0 || !Number.isInteger(max)) {
+    throw new Error('unbiasedRandomInt: max must be a positive integer')
+  }
+  const range = 0x1_0000_0000 // 2^32
+  const limit = Math.floor(range / max) * max
+  const buf = new Uint32Array(1)
+  // Loop terminates: P(reject) = (range - limit) / range < max / range,
+  // which is microscopic for our inputs.
+  for (;;) {
+    crypto.getRandomValues(buf)
+    if (buf[0] < limit) return buf[0] % max
+  }
 }

--- a/src/shared/importExport/bundle.ts
+++ b/src/shared/importExport/bundle.ts
@@ -1,0 +1,316 @@
+/**
+ * Encrypted .raftbundle session sharing
+ *
+ * Exports a single Session as an end-to-end encrypted file the user can
+ * hand to someone out-of-band. Reuses the cloud-sync encryption primitives
+ * (PBKDF2 600k + AES-256-GCM) so the trust surface is the same.
+ *
+ * Bundle envelope shape — JSON, file-shaped (not Drive-shaped):
+ *   { v: 1, salt, iv, ct, iterations }
+ */
+
+import type { Session } from '../types'
+import {
+  PBKDF2_ITERATIONS,
+  generateSalt,
+  deriveKey,
+  encryptObject,
+  decryptObject,
+} from '../cloudSync/encryption'
+
+/** Current bundle envelope version. */
+export const BUNDLE_VERSION = 1
+
+/** File extension used for downloaded bundles. */
+export const BUNDLE_EXTENSION = '.raftbundle'
+
+/** MIME type used for bundle blobs. */
+export const BUNDLE_MIME_TYPE = 'application/x-raftbundle+json'
+
+/**
+ * On-disk envelope. `salt` is the PBKDF2 salt for this file, `iv` and `ct`
+ * are the AES-GCM IV and ciphertext. `iterations` is recorded so a future
+ * bump (or downgrade for legacy bundles) round-trips correctly.
+ */
+export interface RaftBundleEnvelope {
+  v: typeof BUNDLE_VERSION
+  salt: string
+  iv: string
+  ct: string
+  iterations: number
+}
+
+/**
+ * Encrypt a session into a downloadable .raftbundle Blob.
+ *
+ * Generates a fresh salt + IV per export so two exports of the same
+ * session under the same passphrase produce different ciphertexts.
+ */
+export async function exportBundle(session: Session, passphrase: string): Promise<globalThis.Blob> {
+  if (!passphrase) {
+    throw new Error('Passphrase required to export bundle')
+  }
+
+  const salt = generateSalt()
+  const key = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS)
+  const payload = await encryptObject(session, key)
+
+  const envelope: RaftBundleEnvelope = {
+    v: BUNDLE_VERSION,
+    salt,
+    iv: payload.iv,
+    ct: payload.ct,
+    iterations: PBKDF2_ITERATIONS,
+  }
+
+  const json = JSON.stringify(envelope)
+  return new globalThis.Blob([json], { type: BUNDLE_MIME_TYPE })
+}
+
+/**
+ * Type guard for the envelope shape. Anything missing a required field
+ * is rejected before we even try to derive a key.
+ */
+export function isRaftBundleEnvelope(value: unknown): value is RaftBundleEnvelope {
+  if (!value || typeof value !== 'object') return false
+  const e = value as Record<string, unknown>
+  return (
+    e.v === BUNDLE_VERSION &&
+    typeof e.salt === 'string' &&
+    typeof e.iv === 'string' &&
+    typeof e.ct === 'string' &&
+    typeof e.iterations === 'number'
+  )
+}
+
+/**
+ * Parse a string (or Blob's text contents) into a validated envelope.
+ * Throws with a useful message on malformed input.
+ */
+export function parseEnvelope(content: string): RaftBundleEnvelope {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    throw new Error('Not a valid Raft bundle: file is not JSON')
+  }
+  if (!isRaftBundleEnvelope(parsed)) {
+    throw new Error('Not a valid Raft bundle: envelope shape is wrong')
+  }
+  return parsed
+}
+
+/**
+ * Convenience: read a Blob (or pass through a string) and parse it as an
+ * envelope in one call. Useful for tests that just want to inspect the
+ * envelope shape without decrypting.
+ */
+export async function readEnvelope(input: globalThis.Blob | string): Promise<RaftBundleEnvelope> {
+  return parseEnvelope(await blobToText(input))
+}
+
+/**
+ * Read a Blob into a string. Prefers the standard `Blob.text()`, falls back
+ * to `FileReader` for environments (some Blob polyfills, older jsdom) that
+ * don't implement it. Accepts a raw string passthrough for convenience —
+ * callers can hand us either form.
+ */
+async function blobToText(input: globalThis.Blob | string): Promise<string> {
+  if (typeof input === 'string') return input
+  if (typeof (input as { text?: unknown }).text === 'function') {
+    return input.text()
+  }
+  if (typeof (input as { arrayBuffer?: unknown }).arrayBuffer === 'function') {
+    const buf = await input.arrayBuffer()
+    return new TextDecoder().decode(buf)
+  }
+  return new Promise<string>((resolve, reject) => {
+    const reader = new globalThis.FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read blob'))
+    reader.readAsText(input as globalThis.Blob)
+  })
+}
+
+/**
+ * Decrypt a .raftbundle blob back into a Session.
+ *
+ * Wrong-passphrase failures (AES-GCM auth tag mismatch) are surfaced as
+ * a clean `Error('Incorrect passphrase ...')` so callers can show the
+ * user something useful instead of a raw OperationError.
+ *
+ * Accepts a Blob or a raw string (the JSON envelope) so callers don't have
+ * to wrap text in a Blob just to round-trip it.
+ */
+export async function importBundle(
+  blob: globalThis.Blob | string,
+  passphrase: string
+): Promise<Session> {
+  if (!passphrase) {
+    throw new Error('Passphrase required to import bundle')
+  }
+
+  const text = await blobToText(blob)
+  const envelope = parseEnvelope(text)
+
+  const key = await deriveKey(passphrase, envelope.salt, envelope.iterations)
+
+  try {
+    return await decryptObject<Session>({ v: 1, iv: envelope.iv, ct: envelope.ct }, key)
+  } catch {
+    throw new Error('Incorrect passphrase or corrupted bundle')
+  }
+}
+
+/**
+ * Build a download filename for a session bundle.
+ * Sanitizes the session name to a filesystem-safe slug.
+ */
+export function bundleFilename(session: Session): string {
+  const slug =
+    session.name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'session'
+  const date = new Date().toISOString().split('T')[0]
+  return `raft-${slug}-${date}${BUNDLE_EXTENSION}`
+}
+
+/**
+ * Generate a high-entropy passphrase suitable for one-time bundle sharing.
+ * 6 words from a small wordlist + 4-digit number gives ~70 bits of entropy
+ * while staying readable enough to dictate over a phone call.
+ */
+export function generateBundlePassphrase(): string {
+  // Short, common, unambiguous. Picked to avoid lookalike letters and
+  // anything that would be embarrassing to read aloud.
+  const words = [
+    'amber',
+    'anchor',
+    'apple',
+    'arrow',
+    'atlas',
+    'banjo',
+    'basin',
+    'beach',
+    'birch',
+    'blaze',
+    'bloom',
+    'brave',
+    'breeze',
+    'brick',
+    'bronze',
+    'cabin',
+    'canyon',
+    'cedar',
+    'chase',
+    'cider',
+    'cliff',
+    'cloud',
+    'clover',
+    'comet',
+    'coral',
+    'crane',
+    'crisp',
+    'crown',
+    'crystal',
+    'dawn',
+    'delta',
+    'denim',
+    'desert',
+    'diamond',
+    'dolphin',
+    'dune',
+    'eagle',
+    'ember',
+    'falcon',
+    'fern',
+    'fjord',
+    'flame',
+    'flint',
+    'forest',
+    'galaxy',
+    'garden',
+    'gentle',
+    'glacier',
+    'gold',
+    'granite',
+    'harbor',
+    'harvest',
+    'hawk',
+    'heron',
+    'hollow',
+    'honey',
+    'horizon',
+    'island',
+    'ivory',
+    'jade',
+    'juniper',
+    'kettle',
+    'lagoon',
+    'lantern',
+    'lily',
+    'linen',
+    'lotus',
+    'maple',
+    'meadow',
+    'mellow',
+    'mesa',
+    'mint',
+    'misty',
+    'morning',
+    'mountain',
+    'nectar',
+    'nimbus',
+    'oak',
+    'ocean',
+    'olive',
+    'opal',
+    'orchid',
+    'otter',
+    'pebble',
+    'phoenix',
+    'pine',
+    'plum',
+    'prairie',
+    'quartz',
+    'quiet',
+    'rain',
+    'raven',
+    'reef',
+    'river',
+    'robin',
+    'sable',
+    'sage',
+    'sapphire',
+    'shadow',
+    'silver',
+    'spark',
+    'spring',
+    'stone',
+    'storm',
+    'stream',
+    'summit',
+    'sunrise',
+    'swan',
+    'tide',
+    'topaz',
+    'trail',
+    'tulip',
+    'twilight',
+    'valley',
+    'velvet',
+    'violet',
+    'wander',
+    'willow',
+    'winter',
+    'zephyr',
+  ]
+
+  const buf = crypto.getRandomValues(new Uint32Array(6))
+  const picks = Array.from(buf, (n) => words[n % words.length])
+  const num = crypto.getRandomValues(new Uint32Array(1))[0] % 10000
+  return `${picks.join('-')}-${num.toString().padStart(4, '0')}`
+}

--- a/src/shared/importExport/index.ts
+++ b/src/shared/importExport/index.ts
@@ -26,9 +26,25 @@ export { parseSessionBuddy } from './parsers/sessionBuddy'
 export { parseTabSessionManager } from './parsers/tabSessionManager'
 export { parseToby } from './parsers/toby'
 export { parseRaft } from './parsers/raft'
+export { parseRaftbundle } from './parsers/raftbundle'
 
 // Re-export exporters
 export { exportAsJson, exportAsText, exportSessions, downloadExport } from './exporters'
+
+// Re-export encrypted bundle export/import
+export {
+  exportBundle,
+  importBundle,
+  bundleFilename,
+  generateBundlePassphrase,
+  parseEnvelope as parseBundleEnvelope,
+  readEnvelope as readBundleEnvelope,
+  isRaftBundleEnvelope,
+  BUNDLE_VERSION,
+  BUNDLE_EXTENSION,
+  BUNDLE_MIME_TYPE,
+} from './bundle'
+export type { RaftBundleEnvelope } from './bundle'
 
 // Main import function
 import type { ImportResult, ImportFormat } from './types'
@@ -78,6 +94,28 @@ export function importSessions(content: string): ImportResult {
       return parseToby(content)
     case 'raft':
       return parseRaft(content)
+    case 'raftbundle':
+      // Encrypted bundles need a passphrase, which auto-import can't supply.
+      // Surface a useful message; the panel handles bundles via parseRaftbundle directly.
+      return {
+        success: false,
+        sessions: [],
+        errors: [
+          {
+            message:
+              'Encrypted Raft bundle detected — use the encrypted bundle import to enter the passphrase.',
+          },
+        ],
+        warnings: [],
+        stats: {
+          totalEntries: 0,
+          validUrls: 0,
+          skippedUrls: 0,
+          sessionsCreated: 0,
+          tabsImported: 0,
+        },
+        format: 'raftbundle',
+      }
     default:
       return {
         success: false,
@@ -110,6 +148,8 @@ export function getFormatDisplayName(format: ImportFormat): string {
       return 'Toby'
     case 'raft':
       return 'Raft'
+    case 'raftbundle':
+      return 'Raft (encrypted bundle)'
     default:
       return format
   }

--- a/src/shared/importExport/parsers/raftbundle.ts
+++ b/src/shared/importExport/parsers/raftbundle.ts
@@ -1,0 +1,68 @@
+/**
+ * Encrypted .raftbundle import parser
+ *
+ * Unlike the other parsers, this one needs a passphrase — bundles are
+ * end-to-end encrypted with PBKDF2 + AES-256-GCM. The signature is async
+ * and takes the passphrase explicitly; the panel calls it directly rather
+ * than going through `importSessions`, since auto-detect can't supply
+ * a passphrase.
+ */
+
+import type { Session } from '../../types'
+import type { ImportResult, ImportError, ImportStats } from '../types'
+import { importBundle } from '../bundle'
+
+/**
+ * Decrypt a .raftbundle file and produce an ImportResult shaped like
+ * the other parsers so the panel's success/error UI can reuse the same
+ * code path.
+ *
+ * The Session inside the bundle is preserved as-is (IDs intact). The
+ * caller decides what to do with it — the round-trip safety contract
+ * is "bytes you put in, bytes you get out".
+ */
+export async function parseRaftbundle(
+  content: string | globalThis.Blob,
+  passphrase: string
+): Promise<ImportResult> {
+  const stats: ImportStats = {
+    totalEntries: 0,
+    validUrls: 0,
+    skippedUrls: 0,
+    sessionsCreated: 0,
+    tabsImported: 0,
+  }
+  const errors: ImportError[] = []
+  const warnings: ImportError[] = []
+
+  let session: Session
+  try {
+    session = await importBundle(content, passphrase)
+  } catch (e) {
+    return {
+      success: false,
+      sessions: [],
+      errors: [{ message: e instanceof Error ? e.message : 'Failed to decrypt bundle' }],
+      warnings: [],
+      stats,
+      format: 'raftbundle',
+    }
+  }
+
+  // Recompute stats from the decrypted session so the UI summary works.
+  for (const window of session.windows) {
+    stats.totalEntries += window.tabs.length
+    stats.validUrls += window.tabs.length
+  }
+  stats.sessionsCreated = 1
+  stats.tabsImported = stats.validUrls
+
+  return {
+    success: true,
+    sessions: [session],
+    errors,
+    warnings,
+    stats,
+    format: 'raftbundle',
+  }
+}

--- a/src/shared/importExport/types.ts
+++ b/src/shared/importExport/types.ts
@@ -7,7 +7,13 @@ import type { Session } from '../types'
 /**
  * Supported import formats
  */
-export type ImportFormat = 'onetab' | 'sessionBuddy' | 'tabSessionManager' | 'toby' | 'raft'
+export type ImportFormat =
+  | 'onetab'
+  | 'sessionBuddy'
+  | 'tabSessionManager'
+  | 'toby'
+  | 'raft'
+  | 'raftbundle'
 
 /**
  * Individual import error with context

--- a/src/shared/importExport/validators.ts
+++ b/src/shared/importExport/validators.ts
@@ -86,6 +86,17 @@ export function detectImportFormat(content: string): ImportFormat | null {
     try {
       const parsed = JSON.parse(trimmed)
 
+      // Check for encrypted Raft bundle envelope (file-shaped, not Drive-shaped)
+      if (
+        parsed.v === 1 &&
+        typeof parsed.salt === 'string' &&
+        typeof parsed.iv === 'string' &&
+        typeof parsed.ct === 'string' &&
+        typeof parsed.iterations === 'number'
+      ) {
+        return 'raftbundle'
+      }
+
       // Check for Raft format (has version and raftVersion fields)
       if (parsed.version && parsed.raftVersion && Array.isArray(parsed.sessions)) {
         return 'raft'

--- a/tests/safety/encrypted-bundle.test.ts
+++ b/tests/safety/encrypted-bundle.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Encrypted Bundle Safety Tests
+ *
+ * Asserts that `.raftbundle` export/import:
+ *   1. Never touches the network (no fetch / XHR / WebSocket calls).
+ *   2. Round-trips a realistic session (50 tabs + groups) bit-for-bit.
+ *   3. Surfaces a clean, useful error on the wrong passphrase.
+ *   4. Uses the 600k PBKDF2 default and embeds it in the envelope.
+ *
+ * The "no network" check is the key trust property: end-to-end-encrypted
+ * sharing must be a fully local operation. If we ever accidentally ship a
+ * codepath that reaches out to a server, this test fires.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  exportBundle,
+  importBundle,
+  readEnvelope,
+  generateBundlePassphrase,
+  BUNDLE_VERSION,
+} from '@/shared/importExport/bundle'
+import { parseRaftbundle } from '@/shared/importExport/parsers/raftbundle'
+import { PBKDF2_ITERATIONS } from '@/shared/cloudSync/encryption'
+import type { Session } from '@/shared/types'
+import { buildLargeSession } from './helpers'
+
+describe('Encrypted .raftbundle export/import', () => {
+  describe('Never reaches the network', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>
+    let xhrSpy: ReturnType<typeof vi.fn>
+    let wsSpy: ReturnType<typeof vi.fn>
+    let originalFetch: typeof globalThis.fetch | undefined
+    let originalXhr: typeof globalThis.XMLHttpRequest | undefined
+    let originalWs: typeof globalThis.WebSocket | undefined
+
+    beforeEach(() => {
+      // Replace any network-capable global with a spy that throws if called.
+      // If a future change accidentally introduces an HTTP call inside
+      // exportBundle/importBundle, one of these spies will be invoked
+      // and the test will fail loudly.
+      originalFetch = globalThis.fetch
+      originalXhr = globalThis.XMLHttpRequest
+      originalWs = globalThis.WebSocket
+
+      fetchSpy = vi.fn(() => {
+        throw new Error('fetch must not be called from bundle export/import')
+      })
+      xhrSpy = vi.fn(() => {
+        throw new Error('XMLHttpRequest must not be used from bundle export/import')
+      })
+      wsSpy = vi.fn(() => {
+        throw new Error('WebSocket must not be used from bundle export/import')
+      })
+
+      globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch
+      globalThis.XMLHttpRequest =
+        xhrSpy as unknown as typeof globalThis.XMLHttpRequest
+      globalThis.WebSocket = wsSpy as unknown as typeof globalThis.WebSocket
+    })
+
+    afterEach(() => {
+      if (originalFetch) globalThis.fetch = originalFetch
+      else delete (globalThis as { fetch?: unknown }).fetch
+      if (originalXhr) globalThis.XMLHttpRequest = originalXhr
+      if (originalWs) globalThis.WebSocket = originalWs
+    })
+
+    it('exportBundle and importBundle make zero network calls', async () => {
+      const session = buildLargeSession(2, 5, 2)
+      const passphrase = 'correct-horse-battery-staple'
+
+      const blob = await exportBundle(session, passphrase)
+      const restored = await importBundle(blob, passphrase)
+
+      expect(restored.id).toBe(session.id)
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(xhrSpy).not.toHaveBeenCalled()
+      expect(wsSpy).not.toHaveBeenCalled()
+    })
+
+    it('parseRaftbundle (the parser entry) is also network-free', async () => {
+      const session = buildLargeSession(1, 3, 1)
+      const passphrase = 'bundle-test-passphrase'
+      const blob = await exportBundle(session, passphrase)
+
+      // Pass the Blob through directly — parseRaftbundle accepts both forms.
+      const result = await parseRaftbundle(blob, passphrase)
+
+      expect(result.success).toBe(true)
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(xhrSpy).not.toHaveBeenCalled()
+      expect(wsSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Round-trip preserves a 50-tab session bit-for-bit', () => {
+    it('exports 50 tabs across multiple windows + groups, re-imports identically', async () => {
+      // 5 windows × 10 tabs = 50 tabs, with 3 groups per window so group/tab
+      // membership is exercised.
+      const original: Session = buildLargeSession(5, 10, 3)
+      const tabCount = original.windows.reduce((n, w) => n + w.tabs.length, 0)
+      expect(tabCount).toBe(50)
+
+      const passphrase = generateBundlePassphrase()
+      const blob = await exportBundle(original, passphrase)
+      const restored = await importBundle(blob, passphrase)
+
+      // Bit-identical: every field, every ID, every group color, every index.
+      expect(restored).toEqual(original)
+    })
+
+    it('parseRaftbundle yields the same Session that importBundle returns', async () => {
+      const original = buildLargeSession(2, 25, 2)
+      const passphrase = 'shared-channel-passphrase'
+      const blob = await exportBundle(original, passphrase)
+
+      const direct = await importBundle(blob, passphrase)
+      const viaParser = await parseRaftbundle(blob, passphrase)
+
+      expect(viaParser.success).toBe(true)
+      expect(viaParser.sessions).toHaveLength(1)
+      expect(viaParser.sessions[0]).toEqual(direct)
+      expect(viaParser.stats.tabsImported).toBe(50)
+      expect(viaParser.format).toBe('raftbundle')
+    })
+  })
+
+  describe('Bad passphrase fails cleanly', () => {
+    it('importBundle throws a useful error when the passphrase is wrong', async () => {
+      const session = buildLargeSession(1, 5)
+      const blob = await exportBundle(session, 'right-passphrase')
+
+      await expect(importBundle(blob, 'wrong-passphrase')).rejects.toThrow(
+        /incorrect passphrase|corrupted/i
+      )
+    })
+
+    it('parseRaftbundle returns a failed ImportResult with a useful error', async () => {
+      const session = buildLargeSession(1, 5)
+      const blob = await exportBundle(session, 'right-passphrase')
+
+      const result = await parseRaftbundle(blob, 'wrong-passphrase')
+
+      expect(result.success).toBe(false)
+      expect(result.sessions).toHaveLength(0)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].message).toMatch(/incorrect passphrase|corrupted/i)
+      expect(result.format).toBe('raftbundle')
+    })
+
+    it('rejects malformed envelopes without trying to derive a key', async () => {
+      const result = await parseRaftbundle('not-json', 'whatever')
+      expect(result.success).toBe(false)
+      expect(result.errors[0].message).toMatch(/not a valid raft bundle/i)
+    })
+
+    it('rejects envelopes missing required fields', async () => {
+      const result = await parseRaftbundle('{"v":1}', 'whatever')
+      expect(result.success).toBe(false)
+      expect(result.errors[0].message).toMatch(/envelope shape/i)
+    })
+
+    it('importBundle requires a passphrase', async () => {
+      const session = buildLargeSession(1, 1)
+      const blob = await exportBundle(session, 'pw')
+      await expect(importBundle(blob, '')).rejects.toThrow(/passphrase required/i)
+    })
+
+    it('exportBundle requires a passphrase', async () => {
+      const session = buildLargeSession(1, 1)
+      await expect(exportBundle(session, '')).rejects.toThrow(/passphrase required/i)
+    })
+  })
+
+  describe('Envelope uses the 600k PBKDF2 default', () => {
+    it('records iterations: 600_000 in the envelope', async () => {
+      const session = buildLargeSession(1, 2)
+      const blob = await exportBundle(session, 'any-passphrase')
+      const envelope = await readEnvelope(blob)
+
+      expect(envelope.iterations).toBe(PBKDF2_ITERATIONS)
+      expect(PBKDF2_ITERATIONS).toBe(600_000)
+      expect(envelope.v).toBe(BUNDLE_VERSION)
+      expect(typeof envelope.salt).toBe('string')
+      expect(typeof envelope.iv).toBe('string')
+      expect(typeof envelope.ct).toBe('string')
+    })
+
+    it('two exports of the same session produce different ciphertexts (fresh salt+iv)', async () => {
+      const session = buildLargeSession(1, 3)
+      const blob1 = await exportBundle(session, 'pw')
+      const blob2 = await exportBundle(session, 'pw')
+
+      const env1 = await readEnvelope(blob1)
+      const env2 = await readEnvelope(blob2)
+
+      expect(env1.salt).not.toBe(env2.salt)
+      expect(env1.iv).not.toBe(env2.iv)
+      expect(env1.ct).not.toBe(env2.ct)
+    })
+  })
+
+  describe('Generated passphrase is high-entropy', () => {
+    it('produces unique passphrases on repeated calls', () => {
+      const seen = new Set<string>()
+      for (let i = 0; i < 50; i++) {
+        seen.add(generateBundlePassphrase())
+      }
+      // No collisions in 50 draws — confirms the wordlist+digit space is
+      // doing real work and not silently returning a constant.
+      expect(seen.size).toBe(50)
+    })
+
+    it('passphrase has the expected shape (6 words + 4 digits)', () => {
+      const pw = generateBundlePassphrase()
+      // word-word-word-word-word-word-NNNN
+      expect(pw).toMatch(/^[a-z]+(-[a-z]+){5}-\d{4}$/)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds an "Encrypt & share" action on each saved session that produces a passphrase + downloadable `.raftbundle` file. Recipient drops the file into the import panel, enters the passphrase out-of-band, and picks which tabs to bring in.
- Reuses the existing PBKDF2 (600k) + AES-256-GCM primitives from `cloudSync/encryption.ts`. File-shaped envelope: `{ v: 1, salt, iv, ct, iterations }`. Zero servers, zero accounts, no auto-encryption — the user explicitly opts in per export.
- Passphrase dialog shows the passphrase once, warns to share it through a different channel than the file, and has separate Copy / Download buttons on purpose.

## Trust surface
- Safety test (`tests/safety/encrypted-bundle.test.ts`) asserts export + import make zero `fetch` / `XMLHttpRequest` / `WebSocket` calls.
- Round-trip test exports a 50-tab + 3-groups-per-window session and asserts the restored Session is bit-for-bit `toEqual` to the original.
- Wrong passphrase surfaces a clean "Incorrect passphrase or corrupted bundle" error; malformed envelopes are rejected before any key derivation.
- Envelope test pins the iteration count at 600,000 and confirms fresh salt+IV per export.

## Files
- `src/shared/importExport/bundle.ts` — `exportBundle`, `importBundle`, envelope helpers, `generateBundlePassphrase` (6 words + 4 digits).
- `src/shared/importExport/parsers/raftbundle.ts` — async parser entry returning the standard `ImportResult`.
- `src/shared/importExport/{index,types,validators}.ts` — register the new format and route bundles past the auto-detect importer.
- `src/options/components/ImportExportPanel.tsx` — per-session export action, passphrase modal, decrypt + tab-picker import flow. Also fixes a pre-existing double-fire on the Choose File button.
- `tests/safety/encrypted-bundle.test.ts` — 14 tests covering the above.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` (759 / 759 passing)
- [x] Manual: export a session, copy passphrase, download bundle, re-import in the same profile with a new ID, confirm tab-picker selects subset correctly
- [x] Manual: wrong passphrase produces inline error, dialog stays open
- [x] Manual: dropping a `.raftbundle` renamed to `.json` still routes through the passphrase prompt (envelope sniff)

## Non-goals
- No cloud-shareable links (would require a server).
- No auto-encryption — explicit user action only.

https://claude.ai/code/session_01Kv2npptMMD2BV3y7dxjp1X

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kv2npptMMD2BV3y7dxjp1X)_